### PR TITLE
fix compatibility for old version

### DIFF
--- a/app/src/main/java/me/iacn/biliroaming/BiliBiliPackage.kt
+++ b/app/src/main/java/me/iacn/biliroaming/BiliBiliPackage.kt
@@ -49,7 +49,7 @@ class BiliBiliPackage constructor(private val mClassLoader: ClassLoader, mContex
     val libBiliClass by Weak { "com.bilibili.nativelibrary.LibBili".findClass(mClassLoader) }
     val splashActivityClass by Weak { "tv.danmaku.bili.ui.splash.SplashActivity".findClass(mClassLoader) }
     val mainActivityClass by Weak { "tv.danmaku.bili.MainActivityV2".findClass(mClassLoader) }
-    val homeUserCenterClass by Weak { "tv.danmaku.bili.ui.main2.mine.HomeUserCenterFragment".findClass(mClassLoader) }
+    val homeUserCenterClass by Weak { "tv.danmaku.bili.ui.main2.mine.HomeUserCenterFragment".findClassOrNull(mClassLoader) }
     val garbHelperClass by Weak { mHookInfo["class_garb_helper"]?.findClass(mClassLoader) }
     val musicNotificationHelperClass by Weak { mHookInfo["class_music_notification_helper"]?.findClass(mClassLoader) }
     val notificationBuilderClass by Weak { mHookInfo["class_notification_builder"]?.findClass(mClassLoader) }
@@ -60,7 +60,7 @@ class BiliBiliPackage constructor(private val mClassLoader: ClassLoader, mContex
                 ?: "android.support.v4.widget.DrawerLayout".findClass(mClassLoader)
     }
     val drawerLayoutParamsClass by Weak { mHookInfo["class_drawer_layout_params"]?.findClass(mClassLoader) }
-    val splashInfoClass by Weak { "tv.danmaku.bili.ui.splash.brand.BrandShowInfo".findClass(mClassLoader) }
+    val splashInfoClass by Weak { "tv.danmaku.bili.ui.splash.brand.BrandShowInfo".findClassOrNull(mClassLoader) }
     val commentRpcClass by Weak { "com.bilibili.app.comm.comment2.model.rpc.CommentRpcKt".findClassOrNull(mClassLoader) }
     val checkBlueClass by Weak { mHookInfo["class_check_blue"]?.findClass(mClassLoader) }
     val kotlinJsonClass by Weak { "kotlinx.serialization.json.Json".findClassOrNull(mClassLoader) }

--- a/app/src/main/java/me/iacn/biliroaming/SettingDialog.kt
+++ b/app/src/main/java/me/iacn/biliroaming/SettingDialog.kt
@@ -88,7 +88,7 @@ class SettingDialog(context: Context) : AlertDialog.Builder(context) {
         }
 
         private fun checkCompatibleVersion() {
-            val versionCode = currentContext.packageManager.getPackageInfo(packageName, 0).versionCode
+            val versionCode = getVersionCode(packageName)
             var supportLiveHook = false
             var supportAdd4K = false
             var supportMusicNotificationHook = true

--- a/app/src/main/java/me/iacn/biliroaming/hook/BangumiPlayUrlHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/BangumiPlayUrlHook.kt
@@ -97,7 +97,7 @@ class BangumiPlayUrlHook(classLoader: ClassLoader) : BaseHook(classLoader) {
             }
         }
 
-        "com.bapis.bilibili.pgc.gateway.player.v1.PlayURLMoss".findClass(mClassLoader)?.run {
+        "com.bapis.bilibili.pgc.gateway.player.v1.PlayURLMoss".findClassOrNull(mClassLoader)?.run {
             var isDownload = false
             hookBeforeMethod("playView",
                     "com.bapis.bilibili.pgc.gateway.player.v1.PlayViewReq") { param ->


### PR DESCRIPTION
主要改了两个地方
1. 旧国际版没有 `MOBI_APP` 导致 platform 被识别成了标准版，加了条通过包名判断
2. 有些“去除更新”的修改版是通过在 `versionCode` 前加 9 实现的，加了几行判断前面有多少个 9 ，去掉前面的 9 再在最后加 0 ，从而实现获取到正确的版本号

剩下的就是对旧版中不存在的 class 使用 `findClassOrNull` 而不是 `findClass` 来减少对 xposed log 的刷屏