### PR TITLE
移除首页广告

### DIFF
--- a/app/src/main/java/me/iacn/biliroaming/hook/BangumiSeasonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/BangumiSeasonHook.kt
@@ -247,6 +247,13 @@ class BangumiSeasonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
         body.getObjectField("data")?.getObjectFieldAs<ArrayList<Any>>("items")?.apply {
             val old = size
             removeAll {
+                "ad" in (it.getObjectFieldAs("cardGoto") ?: "")
+            }
+            Log.toast("移除广告 x${old - size}")
+        }
+        body.getObjectField("data")?.getObjectFieldAs<ArrayList<Any>>("items")?.apply {
+            val old = size
+            removeAll {
                 "large_cover_v9" in (it.getObjectFieldAs("cardType") ?: "")
             }
             Log.toast("移除宽推荐 x${old - size}")

--- a/app/src/main/java/me/iacn/biliroaming/hook/BangumiSeasonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/BangumiSeasonHook.kt
@@ -247,9 +247,9 @@ class BangumiSeasonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
         body.getObjectField("data")?.getObjectFieldAs<ArrayList<Any>>("items")?.apply {
             val old = size
             removeAll {
-                "ad" in (it.getObjectFieldAs("cardGoto") ?: "")
+                "large_cover_v9" in (it.getObjectFieldAs("cardType") ?: "")
             }
-            Log.toast("移除广告 x${old - size}")
+            Log.toast("移除宽推荐 x${old - size}")
         }
     }
 

--- a/app/src/main/java/me/iacn/biliroaming/hook/BangumiSeasonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/BangumiSeasonHook.kt
@@ -131,8 +131,7 @@ class BangumiSeasonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                 if (url != null && url.startsWith("https://appintl.biliapi.net/intl/gateway/app/search/type") && !url.contains("type=$TH_TYPE")) {
                     fixPlaySearchType(body, url)
                 }
-                if (url != null && url.startsWith("https://app.bilibili.com/x/v2/feed/index") && sPrefs.getBoolean("remove_index_ads", false) && !url.contains("/converge") && !url.contains("/tab") && !url.contains("/story")) {
-                    Log.d("startHook: RemoveIndexAds: url= "+url)
+                if (url != null && url.startsWith("https://app.bilibili.com/x/v2/feed/index") && sPrefs.getBoolean("purify_home_recommend", false) && !url.contains("/converge") && !url.contains("/tab") && !url.contains("/story")) {
                     removeIndexAds(body)
                 }
                 if (instance.generalResponseClass?.isInstance(body) == true || instance.rxGeneralResponseClass?.isInstance(body) == true) {

--- a/app/src/main/java/me/iacn/biliroaming/hook/BangumiSeasonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/BangumiSeasonHook.kt
@@ -252,11 +252,9 @@ class BangumiSeasonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
             Log.toast("移除广告 x${old - size}")
         }
         body.getObjectField("data")?.getObjectFieldAs<ArrayList<Any>>("items")?.apply {
-            val old = size
             removeAll {
                 "large_cover_v9" in (it.getObjectFieldAs("cardType") ?: "")
             }
-            Log.toast("移除宽推荐 x${old - size}")
         }
     }
 

--- a/app/src/main/java/me/iacn/biliroaming/hook/BangumiSeasonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/BangumiSeasonHook.kt
@@ -248,7 +248,9 @@ class BangumiSeasonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
             removeAll {
                 "ad" in (it.getObjectFieldAs("cardGoto") ?: "")
             }
-            Log.toast("移除广告 x${old - size}")
+            if (old - size > 0){
+                Log.toast("移除广告 x${old - size}")
+            }
         }
         body.getObjectField("data")?.getObjectFieldAs<ArrayList<Any>>("items")?.apply {
             removeAll {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,4 +158,11 @@
     <string name="customize_danmaku_config_summary">更精细的设置</string>
     <string name="customize_accessKey_title">自定义访问密钥</string>
     <string name="customize_accessKey_summary">自定义发往解析服务器的访问密钥（调试功能，除非明白自己在做什么，否则保持空白）</string>
+    <string name="export_video_title">导出视频</string>
+    <string name="export_video_summary">只支持默认下载位置</string>
+    <string name="purify_home_recommend_title">净化首页推荐</string>
+    <string name="purify_home_recommend_summary">去除首页推荐页面的广告（某些旧版可能无效）</string>
+    <string name="pref_backup">备份和还原</string>
+    <string name="pref_export_title">导出配置</string>
+    <string name="pref_import_title">导入配置</string>
 </resources>

--- a/app/src/main/res/xml/prefs_setting.xml
+++ b/app/src/main/res/xml/prefs_setting.xml
@@ -138,13 +138,13 @@
             android:summary="@string/customize_danmaku_config_summary"
             android:title="@string/customize_danmaku_config_title" />
     </PreferenceCategory>
-    <PreferenceCategory android:title="备份和还原">
+    <PreferenceCategory android:title="@string/pref_backup">
         <Preference
             android:key="pref_export"
-            android:title="导出配置" />
+            android:title="@string/pref_export_title" />
         <Preference
             android:key="pref_import"
-            android:title="导入配置" />
+            android:title="@string/pref_import_title" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/setting_category">
         <SwitchPreference
@@ -200,6 +200,10 @@
             android:summary="@string/customize_home_tab_summary"
             android:title="@string/customize_home_tab_title" />
         <SwitchPreference
+            android:key="purify_home_recommend"
+            android:summary="@string/purify_home_recommend_summary"
+            android:title="@string/purify_home_recommend_title" />
+        <SwitchPreference
             android:dependency="hidden"
             android:key="purify_city"
             android:summary="@string/purify_city_summary"
@@ -216,12 +220,8 @@
             android:title="@string/customize_accessKey_title" />
         <Preference
             android:key="export_video"
-            android:summary="只支持默认下载位置"
-            android:title="导出视频" />
-        <SwitchPreference
-            android:key="remove_index_ads"
-            android:summary="某些旧版可能无效"
-            android:title="移除首页广告" />
+            android:summary="@string/export_video_summary"
+            android:title="@string/export_video_title" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml/prefs_setting.xml
+++ b/app/src/main/res/xml/prefs_setting.xml
@@ -218,6 +218,10 @@
             android:key="export_video"
             android:summary="只支持默认下载位置"
             android:title="导出视频" />
+        <SwitchPreference
+            android:key="remove_index_ads"
+            android:summary="某些旧版可能无效"
+            android:title="移除首页广告" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
代码作者 [https://github.com/yujincheng08/BiliRoaming/pull/146](https://github.com/yujincheng08/BiliRoaming/pull/146) 

我只是复制代码，然后加了一个要移除的内容而已。

以下为本PR和[https://github.com/yujincheng08/BiliRoaming/pull/146](https://github.com/yujincheng08/BiliRoaming/pull/146) 的差异
1. BangumiSeasonHook.kt：加上 L251及253（不要那么频繁的显示toast）
2. BangumiSeasonHook.kt：加上 L.255-259（防止强迫症，干脆把宽的推荐一起给删掉）
3. BangumiSeasonHook.kt：L.134 的 Pref key 改为 purify_home_recommend
4. prefs_setting.xml：将文字都移到 strings.xml。修改 remove_index_ads 改为 purify_home_recommend，并且移动在菜单上的位置
5. strings.xml：加上文字