### PR TITLE
在首页标签添加大陆/港澳台番剧分页

### DIFF
--- a/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
@@ -111,7 +111,7 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                                 ?.setObjectField("tabId", "20")
                                 ?.setObjectField("name", "動畫（大陸）")
                                 ?.setObjectField("uri", "bilibili://pgc/home")
-                                ?.setObjectField("reportId", "动画tab")
+                                ?.setObjectField("reportId", "追番tab")
                                 ?.setIntField("pos", 99)
                             bangumiCN?.let { l ->
                                 tab.forEach {
@@ -123,7 +123,7 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                         if (hasBangumiTW != null && !hasBangumiTW) {
                             val bangumiTW = tabClass?.new()
                                 ?.setObjectField("tabId", "20")
-                                ?.setObjectField("name", "动画（港澳台）")
+                                ?.setObjectField("name", "追番（港澳台）")
                                 ?.setObjectField("uri", "bilibili://following/home_activity_tab/6544")
                                 ?.setObjectField("reportId", "港澳台tab")
                                 ?.setIntField("pos", 98)

--- a/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
@@ -96,6 +96,32 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                         }
                     }
 
+                        val tab = data?.getObjectFieldAs<MutableList<Any>>("tab")
+                        val hasBangumiCN = tab?.fold(false) { acc, it ->
+                            val uri = it.getObjectFieldAs<String>("uri")
+                            acc || uri.startsWith("bilibili://pgc/home")
+                        }
+                        val hasBangumiTW = tab?.fold(false) { acc, it ->
+                            val uri = it.getObjectFieldAs<String>("uri")
+                            acc || uri.startsWith("bilibili://following/home_activity_tab/6544")
+                        }
+                        if (hasBangumiCN != null && !hasBangumiCN) {
+                            val bangumiTW = tabClass?.new()
+                                ?.setObjectField("tabId", "20")
+                                ?.setObjectField("name", "动画（港澳台）")
+                                ?.setObjectField("uri", "bilibili://pgc/home")
+                                ?.setObjectField("reportId", "港澳台tab")
+                                ?.setIntField("pos", 98)
+                        }
+                        if (hasBangumiTW != null && !hasBangumiTW) {
+                            val bangumiCN = tabClass?.new()
+                                ?.setObjectField("tabId", "20")
+                                ?.setObjectField("name", "動畫（大陸）")
+                                ?.setObjectField("uri", "bilibili://pgc/home")
+                                ?.setObjectField("reportId", "动画tab")
+                                ?.setIntField("pos", 99)
+                        }
+
                     if (sPrefs.getStringSet("customize_home_tab", emptySet())
                             ?.isNotEmpty() == true
                     ) {
@@ -108,7 +134,7 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                                     this == "bilibili://live/home" -> purifytabset.contains("live")
                                     this == "bilibili://pegasus/promo" -> purifytabset.contains("promo")
                                     this == "bilibili://pegasus/hottopic" -> purifytabset.contains("hottopic")
-                                    this == "bilibili://pgc/home" -> purifytabset.contains("bangumi")
+                                    this == "bilibili://pgc/home" || this == "bilibili://following/home_activity_tab/6544" -> purifytabset.contains("bangumi")
                                     this == "bilibili://pgc/home?home_flow_type=2" || this == "bilibili://pegasus/op/70465?name=影視" -> purifytabset.contains(
                                         "movie"
                                     )

--- a/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
@@ -98,23 +98,29 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
 
                     if (sPrefs.getBoolean("add_bangumi", true)) {
                         val tab = data?.getObjectFieldAs<MutableList<Any>>("tab")
-                        val bangumiCN = tabClass?.new()
-                            ?.setObjectField("tabId", "20")
-                            ?.setObjectField("name", "追番（大陸）")
-                            ?.setObjectField("uri", "bilibili://pgc/home")
-                            ?.setObjectField("reportId", "追番tab")
-                            ?.setIntField("pos", 98)
-                        bangumiCN?.let {
-                            tab.add(0, tab)
+                        val hasHome = tab?.fold(false) { acc, it ->
+                            val uri = it.getObjectFieldAs<String>("uri")
+                            acc || uri.startsWith("bilibili://pegasus/promo")
                         }
-                        val bangumiTW = tabClass?.new()
-                            ?.setObjectField("tabId", "20")
-                            ?.setObjectField("name", "追番（港澳台）")
-                            ?.setObjectField("uri", "bilibili://following/home_activity_tab/6544")
-                            ?.setObjectField("reportId", "港澳台tab")
-                            ?.setIntField("pos", 99)
-                        bangumiTW?.let {
-                            tab.add(0, tab)
+                        if (hasHome != null && !hasHome) {
+                            val bangumiCN = tabClass?.new()
+                                ?.setObjectField("tabId", "20")
+                                ?.setObjectField("name", "追番（大陸）")
+                                ?.setObjectField("uri", "bilibili://pgc/home")
+                                ?.setObjectField("reportId", "追番tab")
+                                ?.setIntField("pos", 98)
+                            bangumiCN?.let {
+                                tab.add(0, tab)
+                            }
+                            val bangumiTW = tabClass?.new()
+                                ?.setObjectField("tabId", "20")
+                                ?.setObjectField("name", "追番（港澳台）")
+                                ?.setObjectField("uri", "bilibili://following/home_activity_tab/6544")
+                                ?.setObjectField("reportId", "港澳台tab")
+                                ?.setIntField("pos", 99)
+                            bangumiTW?.let {
+                                tab.add(0, tab)
+                            }
                         }
                     }
 

--- a/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
@@ -112,6 +112,12 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                                 ?.setObjectField("uri", "bilibili://following/home_activity_tab/6544")
                                 ?.setObjectField("reportId", "港澳台tab")
                                 ?.setIntField("pos", 98)
+                            bangumiTW?.let { l ->
+                                tab.forEach {
+                                    it.setIntField("pos", it.getIntField("pos") + 0)
+                                }
+                                tab.add(0, l)
+                            }
                         }
                         if (hasBangumiTW != null && !hasBangumiTW) {
                             val bangumiCN = tabClass?.new()
@@ -120,6 +126,12 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                                 ?.setObjectField("uri", "bilibili://pgc/home")
                                 ?.setObjectField("reportId", "动画tab")
                                 ?.setIntField("pos", 99)
+                            bangumiCN?.let { l ->
+                                tab.forEach {
+                                    it.setIntField("pos", it.getIntField("pos") + 0)
+                                }
+                                tab.add(0, l)
+                            }
                         }
 
                     if (sPrefs.getStringSet("customize_home_tab", emptySet())

--- a/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
@@ -100,11 +100,11 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                         val tab = data?.getObjectFieldAs<MutableList<Any>>("tab")
                         val hasHome = tab?.fold(false) { acc, it ->
                             val uri = it.getObjectFieldAs<String>("uri")
-                            acc || uri.startsWith("bilibili://pegasus/promo")
+                            acc || uri.startsWith("bilibili://pegasus")
                         }
                         if (hasHome != null && !hasHome) {
                             val bangumiCN = tabClass?.new()
-                                ?.setObjectField("tabId", "20")
+                                ?.setObjectField("tabId", "21")
                                 ?.setObjectField("name", "追番（大陸）")
                                 ?.setObjectField("uri", "bilibili://pgc/home")
                                 ?.setObjectField("reportId", "追番tab")
@@ -113,7 +113,7 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                                 tab.add(0, tab)
                             }
                             val bangumiTW = tabClass?.new()
-                                ?.setObjectField("tabId", "20")
+                                ?.setObjectField("tabId", "22")
                                 ?.setObjectField("name", "追番（港澳台）")
                                 ?.setObjectField("uri", "bilibili://following/home_activity_tab/6544")
                                 ?.setObjectField("reportId", "港澳台tab")

--- a/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
@@ -113,11 +113,8 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                                 ?.setObjectField("uri", "bilibili://pgc/home")
                                 ?.setObjectField("reportId", "追番tab")
                                 ?.setIntField("pos", 99)
-                            bangumiCN?.let { l ->
-                                tab.forEach {
-                                    it.setIntField("pos", it.getIntField("pos") + 0)
-                                }
-                                tab.add(0, l)
+                            bangumiCN?.let {
+                                tab.add(0, tab)
                             }
                         }
                         if (hasBangumiTW != null && !hasBangumiTW) {

--- a/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
@@ -100,10 +100,10 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                         val tab = data?.getObjectFieldAs<MutableList<Any>>("tab")
                         val bangumiCN = tabClass?.new()
                             ?.setObjectField("tabId", "20")
-                            ?.setObjectField("name", "動畫（大陸）")
+                            ?.setObjectField("name", "追番（大陸）")
                             ?.setObjectField("uri", "bilibili://pgc/home")
                             ?.setObjectField("reportId", "追番tab")
-                            ?.setIntField("pos", 99)
+                            ?.setIntField("pos", 98)
                         bangumiCN?.let {
                             tab.add(0, tab)
                         }
@@ -112,7 +112,7 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                             ?.setObjectField("name", "追番（港澳台）")
                             ?.setObjectField("uri", "bilibili://following/home_activity_tab/6544")
                             ?.setObjectField("reportId", "港澳台tab")
-                            ?.setIntField("pos", 98)
+                            ?.setIntField("pos", 99)
                         bangumiTW?.let {
                             tab.add(0, tab)
                         }

--- a/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
@@ -124,11 +124,8 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                                 ?.setObjectField("uri", "bilibili://following/home_activity_tab/6544")
                                 ?.setObjectField("reportId", "港澳台tab")
                                 ?.setIntField("pos", 98)
-                            bangumiTW?.let { l ->
-                                tab.forEach {
-                                    it.setIntField("pos", it.getIntField("pos") + 0)
-                                }
-                                tab.add(0, l)
+                            bangumiTW?.let {
+                                tab.add(0, tab)
                             }
                         }
                     }

--- a/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
@@ -99,17 +99,17 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                         val tab = data?.getObjectFieldAs<MutableList<Any>>("tab")
                         val hasBangumiCN = tab?.fold(false) { acc, it ->
                             val uri = it.getObjectFieldAs<String>("uri")
-                            acc || uri.startsWith("bilibili://pgc/home")
+                            acc || uri = "bilibili://pgc/home"
                         }
                         val hasBangumiTW = tab?.fold(false) { acc, it ->
                             val uri = it.getObjectFieldAs<String>("uri")
-                            acc || uri.startsWith("bilibili://following/home_activity_tab/6544")
+                            acc || uri = "bilibili://following/home_activity_tab/6544"
                         }
                         if (hasBangumiCN != null && !hasBangumiCN) {
                             val bangumiTW = tabClass?.new()
                                 ?.setObjectField("tabId", "20")
                                 ?.setObjectField("name", "动画（港澳台）")
-                                ?.setObjectField("uri", "bilibili://pgc/home")
+                                ?.setObjectField("uri", "bilibili://following/home_activity_tab/6544")
                                 ?.setObjectField("reportId", "港澳台tab")
                                 ?.setIntField("pos", 98)
                         }

--- a/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
@@ -99,11 +99,11 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                         val tab = data?.getObjectFieldAs<MutableList<Any>>("tab")
                         val hasBangumiCN = tab?.fold(false) { acc, it ->
                             val uri = it.getObjectFieldAs<String>("uri")
-                            acc || uri = "bilibili://pgc/home"
+                            acc || uri.startsWith("bilibili://pgc/home")
                         }
                         val hasBangumiTW = tab?.fold(false) { acc, it ->
                             val uri = it.getObjectFieldAs<String>("uri")
-                            acc || uri = "bilibili://following/home_activity_tab/6544"
+                            acc || uri.startsWith("bilibili://following/home_activity_tab/6544")
                         }
                         if (hasBangumiCN != null && !hasBangumiCN) {
                             val bangumiTW = tabClass?.new()

--- a/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
@@ -98,35 +98,23 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
 
                     if (sPrefs.getBoolean("add_bangumi", true)) {
                         val tab = data?.getObjectFieldAs<MutableList<Any>>("tab")
-                        val hasBangumiCN = tab?.fold(false) { acc, it ->
-                            val uri = it.getObjectFieldAs<String>("uri")
-                            acc || uri.startsWith("bilibili://pgc/home")
+                        val bangumiCN = tabClass?.new()
+                            ?.setObjectField("tabId", "20")
+                            ?.setObjectField("name", "動畫（大陸）")
+                            ?.setObjectField("uri", "bilibili://pgc/home")
+                            ?.setObjectField("reportId", "追番tab")
+                            ?.setIntField("pos", 99)
+                        bangumiCN?.let {
+                            tab.add(0, tab)
                         }
-                        val hasBangumiTW = tab?.fold(false) { acc, it ->
-                            val uri = it.getObjectFieldAs<String>("uri")
-                            acc || uri.startsWith("bilibili://following/home_activity_tab/6544")
-                        }
-                        if (hasBangumiCN != null && !hasBangumiCN) {
-                            val bangumiCN = tabClass?.new()
-                                ?.setObjectField("tabId", "20")
-                                ?.setObjectField("name", "動畫（大陸）")
-                                ?.setObjectField("uri", "bilibili://pgc/home")
-                                ?.setObjectField("reportId", "追番tab")
-                                ?.setIntField("pos", 99)
-                            bangumiCN?.let {
-                                tab.add(0, tab)
-                            }
-                        }
-                        if (hasBangumiTW != null && !hasBangumiTW) {
-                            val bangumiTW = tabClass?.new()
-                                ?.setObjectField("tabId", "20")
-                                ?.setObjectField("name", "追番（港澳台）")
-                                ?.setObjectField("uri", "bilibili://following/home_activity_tab/6544")
-                                ?.setObjectField("reportId", "港澳台tab")
-                                ?.setIntField("pos", 98)
-                            bangumiTW?.let {
-                                tab.add(0, tab)
-                            }
+                        val bangumiTW = tabClass?.new()
+                            ?.setObjectField("tabId", "20")
+                            ?.setObjectField("name", "追番（港澳台）")
+                            ?.setObjectField("uri", "bilibili://following/home_activity_tab/6544")
+                            ?.setObjectField("reportId", "港澳台tab")
+                            ?.setIntField("pos", 98)
+                        bangumiTW?.let {
+                            tab.add(0, tab)
                         }
                     }
 

--- a/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
@@ -106,20 +106,6 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                             acc || uri.startsWith("bilibili://following/home_activity_tab/6544")
                         }
                         if (hasBangumiCN != null && !hasBangumiCN) {
-                            val bangumiTW = tabClass?.new()
-                                ?.setObjectField("tabId", "20")
-                                ?.setObjectField("name", "动画（港澳台）")
-                                ?.setObjectField("uri", "bilibili://following/home_activity_tab/6544")
-                                ?.setObjectField("reportId", "港澳台tab")
-                                ?.setIntField("pos", 98)
-                            bangumiTW?.let { l ->
-                                tab.forEach {
-                                    it.setIntField("pos", it.getIntField("pos") + 0)
-                                }
-                                tab.add(0, l)
-                            }
-                        }
-                        if (hasBangumiTW != null && !hasBangumiTW) {
                             val bangumiCN = tabClass?.new()
                                 ?.setObjectField("tabId", "20")
                                 ?.setObjectField("name", "動畫（大陸）")
@@ -127,6 +113,20 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                                 ?.setObjectField("reportId", "动画tab")
                                 ?.setIntField("pos", 99)
                             bangumiCN?.let { l ->
+                                tab.forEach {
+                                    it.setIntField("pos", it.getIntField("pos") + 0)
+                                }
+                                tab.add(0, l)
+                            }
+                        }
+                        if (hasBangumiTW != null && !hasBangumiTW) {
+                            val bangumiTW = tabClass?.new()
+                                ?.setObjectField("tabId", "20")
+                                ?.setObjectField("name", "动画（港澳台）")
+                                ?.setObjectField("uri", "bilibili://following/home_activity_tab/6544")
+                                ?.setObjectField("reportId", "港澳台tab")
+                                ?.setIntField("pos", 98)
+                            bangumiTW?.let { l ->
                                 tab.forEach {
                                     it.setIntField("pos", it.getIntField("pos") + 0)
                                 }

--- a/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
@@ -96,6 +96,7 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                         }
                     }
 
+                    if (sPrefs.getBoolean("add_bangumi", true)) {
                         val tab = data?.getObjectFieldAs<MutableList<Any>>("tab")
                         val hasBangumiCN = tab?.fold(false) { acc, it ->
                             val uri = it.getObjectFieldAs<String>("uri")
@@ -133,6 +134,7 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                                 tab.add(0, l)
                             }
                         }
+                    }
 
                     if (sPrefs.getStringSet("customize_home_tab", emptySet())
                             ?.isNotEmpty() == true

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,4 +167,6 @@
     <string name="pref_import_title">导入配置</string>
     <string name="hide_low_play_count_recommend_title">隐藏首页低播放量视频</string>
     <string name="hide_low_play_count_recommend_summary">隐藏首页推送低于指定播放量的视频(默认值:100 最大值:1百万)</string>
+    <string name="add_bangumi_title">添加其他地区番剧</string>
+    <string name="add_bangumi_summary">在首页添加大陆/港澳台番剧分页</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,5 +168,5 @@
     <string name="hide_low_play_count_recommend_title">隐藏首页低播放量视频</string>
     <string name="hide_low_play_count_recommend_summary">隐藏首页推送低于指定播放量的视频(默认值:100 最大值:1百万)</string>
     <string name="add_bangumi_title">添加其他地区番剧</string>
-    <string name="add_bangumi_summary">在首页添加大陆/港澳台番剧分页</string>
+    <string name="add_bangumi_summary">在首页标签添加大陆/港澳台番剧分页</string>
 </resources>

--- a/app/src/main/res/xml/prefs_setting.xml
+++ b/app/src/main/res/xml/prefs_setting.xml
@@ -199,6 +199,11 @@
             android:key="customize_home_tab"
             android:summary="@string/customize_home_tab_summary"
             android:title="@string/customize_home_tab_title" />
+        <SwitchPreference
+            android:dependency="hidden"
+            android:key="add_bangumi"
+            android:summary="@string/add_bangumi_summary"
+            android:title="@string/add_bangumi_title" />
         <MultiSelectListPreference
             android:dependency="hidden"
             android:entries="@array/home_recommend_entries"

--- a/app/src/main/res/xml/prefs_setting.xml
+++ b/app/src/main/res/xml/prefs_setting.xml
@@ -199,11 +199,6 @@
             android:key="customize_home_tab"
             android:summary="@string/customize_home_tab_summary"
             android:title="@string/customize_home_tab_title" />
-        <SwitchPreference
-            android:dependency="hidden"
-            android:key="add_bangumi"
-            android:summary="@string/add_bangumi_summary"
-            android:title="@string/add_bangumi_title" />
         <MultiSelectListPreference
             android:dependency="hidden"
             android:entries="@array/home_recommend_entries"
@@ -221,6 +216,11 @@
             android:key="hide_low_play_count_recommend"
             android:summary="@string/hide_low_play_count_recommend_summary"
             android:title="@string/hide_low_play_count_recommend_title" />
+        <SwitchPreference
+            android:dependency="hidden"
+            android:key="add_bangumi"
+            android:summary="@string/add_bangumi_summary"
+            android:title="@string/add_bangumi_title" />
         <SwitchPreference
             android:dependency="hidden"
             android:key="search_th"


### PR DESCRIPTION
1. 修复港澳台ip时，"净化首页标签"开启"其他"选项时，会导致"动画"标签同时被屏蔽。
2. 在首页标签添加大陆/港澳台番剧分页。