### PR TITLE
尝试适配HD版

### DIFF
--- a/app/src/main/java/me/iacn/biliroaming/Constant.kt
+++ b/app/src/main/java/me/iacn/biliroaming/Constant.kt
@@ -8,10 +8,12 @@ object Constant {
     const val PINK_PACKAGE_NAME = "tv.danmaku.bili"
     const val BLUE_PACKAGE_NAME = "com.bilibili.app.blue"
     const val PLAY_PACKAGE_NAME = "com.bilibili.app.in"
+    const val HD_PACKAGE_NAME = "tv.danmaku.bilibilihd"
     val BILIBILI_PACKAGE_NAME = hashMapOf(
         "原版" to PINK_PACKAGE_NAME,
         "概念版" to BLUE_PACKAGE_NAME,
-        "play版" to PLAY_PACKAGE_NAME
+        "play版" to PLAY_PACKAGE_NAME,
+        "HD版" to HD_PACKAGE_NAME
     )
     const val TAG = "BiliRoaming"
     const val HOOK_INFO_FILE_NAME = "hookinfo.dat"

--- a/app/src/main/java/me/iacn/biliroaming/SettingDialog.kt
+++ b/app/src/main/java/me/iacn/biliroaming/SettingDialog.kt
@@ -117,7 +117,8 @@ class SettingDialog(context: Context) : AlertDialog.Builder(context) {
             var supportMusicNotificationHook = true
             var supportDark = true
             var supportCommentFloor = false
-            var supportAddChannel = true
+            var supportAddChannel = false
+            var supportCustomizeTab = true
             val supportFullSplash = try {
                 instance.splashInfoClass?.getMethod("getMode") != null
             } catch (e: Throwable) {
@@ -135,11 +136,16 @@ class SettingDialog(context: Context) : AlertDialog.Builder(context) {
                     if (versionCode < 6080000) supportAdd4K = true
                     if (versionCode < 6000000) supportDark = false
                     if (versionCode < 6180000) supportCommentFloor = true
+                    if (versionCode >= 6270000) supportAddChannel = true
                 }
                 "android" -> {
                     if (versionCode !in 6000000 until 6120000) supportDark = false
                     if (versionCode < 6180000) supportCommentFloor = true
-                    if (versionCode < 6270000) supportAddChannel = false
+                    if (versionCode >= 6270000) supportAddChannel = true
+                }
+                "android_hd" -> {
+                    supportDark = false
+                    supportCustomizeTab = false
                 }
             }
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
@@ -192,6 +198,10 @@ class SettingDialog(context: Context) : AlertDialog.Builder(context) {
             }
             if (!supportAddChannel) {
                 disablePreference("add_channel")
+            }
+            if (!supportCustomizeTab) {
+                disablePreference("customize_home_tab_title")
+                disablePreference("customize_bottom_bar_title")
             }
         }
 

--- a/app/src/main/java/me/iacn/biliroaming/utils/Utils.kt
+++ b/app/src/main/java/me/iacn/biliroaming/utils/Utils.kt
@@ -76,6 +76,7 @@ val appKey = mapOf(
     "tv.danmaku.bili" to "1d8b6e7d45233436",
     "com.bilibili.app.blue" to "07da50c9a0bf829f",
     "com.bilibili.app.in" to "bb3101000e232e27",
+    "tv.danmaku.bilibilihd" to "dfca71928277209b",
 )
 
 val currentContext by lazy { AndroidAppHelper.currentApplication() as Context }
@@ -95,6 +96,7 @@ val platform by lazy {
         ?: when (packageName) {
             Constant.BLUE_PACKAGE_NAME -> "android_b"
             Constant.PLAY_PACKAGE_NAME -> "android_i"
+            Constant.HD_PACKAGE_NAME -> "android_hd"
             else -> "android"
         }
 }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -84,5 +84,6 @@
         <item>tv.danmaku.bili</item>
         <item>com.bilibili.app.blue</item>
         <item>com.bilibili.app.in</item>
+        <item>tv.danmaku.bilibilihd</item>
     </string-array>
 </resources>


### PR DESCRIPTION
- 目前只能从 哔哩漫游 → 打开模块设置 → HD版 来开启设置 (没适配HD版的UI)
- 部分功能看起来有，但是其实没有生效

目前无法使用的功能：
1. 哔哩漫游设置按钮未显示
2. 自定义主题色按钮未显示
3. 自定义同时缓存数
4. 显示AV号 (但是"去你大爷的小程序"开启后，能复制到AV号)
5. 底栏和首页标签无法生效 (看了一下，有api请求，但是app不处理api的结果)