### PR TITLE
Disable show_info toasts by default

### DIFF
--- a/app/src/main/res/xml/prefs_setting.xml
+++ b/app/src/main/res/xml/prefs_setting.xml
@@ -128,7 +128,7 @@
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/setting_category">
         <SwitchPreference
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:key="show_info"
             android:summary="@string/show_info_summary"
             android:title="@string/show_info_title" />


### PR DESCRIPTION
A user may be just too impatient to carefully check every parameter in the settings, so that a toast popping up by default during video playing could be annoying/confusing to such user.

Disabling toast won't break the actual functionality, will it?