### PR TITLE
Add: 增加评论区阿瓦隆检测

### DIFF
--- a/app/src/main/java/me/iacn/biliroaming/XposedInit.kt
+++ b/app/src/main/java/me/iacn/biliroaming/XposedInit.kt
@@ -101,6 +101,7 @@ class XposedInit : IXposedHookLoadPackage, IXposedHookZygoteInit {
                     startHook(QualityHook(lpparam.classLoader))
                     startHook(ReplaceStoryHook(lpparam.classLoader))
                     startHook(PurifyShareHook(lpparam.classLoader))
+                    startHook(ReplyHook(lpparam.classLoader))
                 }
                 lpparam.processName.endsWith(":web") -> {
                     BiliBiliPackage(lpparam.classLoader, param.args[0] as Context)

--- a/app/src/main/java/me/iacn/biliroaming/hook/ReplyHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/ReplyHook.kt
@@ -1,0 +1,90 @@
+package me.iacn.biliroaming.hook
+
+import android.os.Build
+import java.lang.reflect.Array
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import me.iacn.biliroaming.utils.*
+import me.iacn.biliroaming.BiliBiliPackage.Companion.instance
+import me.iacn.biliroaming.network.BiliRoamingApi.checkUpReply
+
+class ReplyHook(classLoader: ClassLoader) : BaseHook(classLoader) {
+    private val jsonNonStrict = lazy {
+        instance.kotlinJsonClass?.getStaticObjectField("Companion")?.callMethod("getNonstrict")
+    }
+    private val isSerializable by lazy {
+        "com.bilibili.bangumi.data.page.detail.entity.BangumiUniformSeason\$\$serializer".findClassOrNull(
+            mClassLoader
+        ) != null
+    }
+    private val isGson by lazy {
+        instance.bangumiUniformSeasonClass?.annotations?.fold(false) { last, it ->
+            last || it.annotationClass.java.name.startsWith("gsonannotator")
+        } ?: false && instance.gsonFromJson() != null && instance.gsonToJson() != null
+    }
+    private val gson by lazy {
+        instance.gson()?.let { instance.gsonConverterClass?.getStaticObjectField(it) }
+    }
+    private val serializerFeatures = lazy {
+        val serializerFeatureClass =
+            "com.alibaba.fastjson.serializer.SerializerFeature".findClassOrNull(mClassLoader)
+                ?: return@lazy null
+        val keyAsString = serializerFeatureClass.getStaticObjectField("WriteNonStringKeyAsString")
+        val noDefault = serializerFeatureClass.getStaticObjectField("NotWriteDefaultValue")
+        val serializerFeatures = Array.newInstance(serializerFeatureClass, 2)
+        Array.set(serializerFeatures, 0, keyAsString)
+        Array.set(serializerFeatures, 1, noDefault)
+        serializerFeatures
+    }
+    private fun Any.toJson() = when {
+        isSerializable -> jsonNonStrict.value?.callMethodAs<String>(
+            "stringify",
+            javaClass.getStaticObjectField("Companion")?.callMethod("serializer"),
+            this
+        ).toJSONObject()
+        isGson -> gson?.callMethodAs<String>(instance.gsonToJson(), this)?.toJSONObject()
+        else -> instance.fastJsonClass?.callStaticMethodAs<String>(
+            "toJSONString",
+            this,
+            serializerFeatures.value
+        ).toJSONObject()
+    }
+    override fun startHook() {
+        if (!sPrefs.getBoolean("check_reply", false)) return
+        Log.d("startHook: Reply")
+        if (isBuiltIn && is64 && Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            Log.e("Not support")
+            Log.toast("Android O以下系统不支持64位Xpatch版，请使用32位版")
+        } else {
+            instance.retrofitResponseClass?.hookBeforeAllConstructors { param ->
+                val url = getUrl(param.args[0])
+                val body = param.args[1] ?: return@hookBeforeAllConstructors
+                if (url != null) {
+                    if (url.startsWith("https://api.bilibili.com/x/v2/reply/add")) {
+                        val rpid = body.getObjectField("data")?.getLongField("rpid")
+                        if (rpid != 0L){
+                            Log.d("ReplyHook rpid: $rpid ")
+                            MainScope().launch {
+                                delay(1000)
+                                val code = checkUpReply(rpid.toString()).toJSONObject().getInt("code")
+                                if (code !=0){
+                                    Log.e("ReplyHook reply return code: $code")
+                                    Log.toast("你刚刚的评论已被阿瓦隆屏蔽")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun getUrl(response: Any): String? {
+        val requestField = instance.requestField() ?: return null
+        val urlField = instance.urlField() ?: return null
+        val request = response.getObjectField(requestField)
+        return request?.getObjectField(urlField)?.toString()
+    }
+
+}

--- a/app/src/main/java/me/iacn/biliroaming/network/BiliRoamingApi.kt
+++ b/app/src/main/java/me/iacn/biliroaming/network/BiliRoamingApi.kt
@@ -37,6 +37,7 @@ object BiliRoamingApi {
     private const val BILI_USER_STATUS_URL = "api.bilibili.com/pgc/view/web/season/user/status"
     private const val BILI_MEDIA_URL = "bangumi.bilibili.com/view/web_api/media"
     private const val BILI_SECTION_URL = "api.bilibili.com/pgc/web/season/section"
+    private const val BILI_CHECK_REPLY_URL = "api.bilibili.com/x/v2/reply/info"
     private const val BILI_MODULE_TEMPLATE =
         "{\"data\": {},\"id\": 0,\"module_style\": {\"hidden\": 0,\"line\": 1},\"more\": \"查看更多\",\"style\": \"positive\",\"title\": \"选集\"}"
     private const val BILI_RIGHT_TEMPLATE =
@@ -689,6 +690,14 @@ object BiliRoamingApi {
         builder.appendQueryParameter("module", "bangumi")
         builder.appendQueryParameter("otype", "json")
         builder.appendQueryParameter("platform", "android")
+        return getContent(builder.toString())
+    }
+
+    @JvmStatic
+    fun checkUpReply(queryString: String?): String? {
+        val builder = Uri.Builder()
+        builder.scheme("https").encodedAuthority(BILI_CHECK_REPLY_URL)
+        builder.appendQueryParameter("rpid", queryString)
         return getContent(builder.toString())
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -176,4 +176,6 @@
     <string name="custom_link_summary">仅支持 bilibili:// 开头的格式</string>
     <string name="add_custom_button_title">在【我的】页面添加自定义按钮</string>
     <string name="add_custom_button_summary">指定修改其中一个项目</string>
+    <string name="check_reply_title">评论区阿瓦隆检测</string>
+    <string name="check_reply_summary">检测评论后是否被“阿瓦隆”系统屏蔽，默认开启\n“阿瓦隆”：B站AI筛选过滤评论系统，屏蔽后该评论将仅对个人显示</string>
 </resources>

--- a/app/src/main/res/xml/prefs_setting.xml
+++ b/app/src/main/res/xml/prefs_setting.xml
@@ -90,6 +90,12 @@
             android:title="@string/comment_copy_enhance_title" />
 
         <SwitchPreference
+            android:key="check_reply"
+            android:summary="@string/check_reply_summary"
+            android:title="@string/check_reply_title"
+            android:defaultValue="true"/>
+
+        <SwitchPreference
             android:key="mini_program"
             android:summary="@string/mini_program_summary"
             android:title="@string/mini_program_title" />


### PR DESCRIPTION
阿瓦隆是B站的AI控评系统，会自动屏蔽评论，被屏蔽的评论只有登录自己账号才能看到，其他账号或者不登录是看不到的
就写了个能检测到评论是否被屏蔽的功能。因为是边写边学的kt，代码是在作者源码上改过来的。我测试下来应该是没有问题的。

效果如下：  
自己视角<a href="https://imgtu.com/i/q5rmh6"><img src="https://s1.ax1x.com/2022/04/01/q5rmh6.md.jpg" alt="q5rmh6.jpg" border="0" height="500px" /></a>游客视角<a href="https://imgtu.com/i/q5rBuQ"><img src="https://s1.ax1x.com/2022/04/01/q5rBuQ.md.jpg" alt="q5rBuQ.jpg" border="0" height="500px"/></a>