### PR TITLE
Add chs and cht subtitle convert each other feature

### DIFF
--- a/app/src/main/java/me/iacn/biliroaming/XposedInit.kt
+++ b/app/src/main/java/me/iacn/biliroaming/XposedInit.kt
@@ -106,6 +106,7 @@ class XposedInit : IXposedHookLoadPackage, IXposedHookZygoteInit {
                     startHook(QualityHook(lpparam.classLoader))
                     startHook(ReplaceStoryHook(lpparam.classLoader))
                     startHook(PurifyShareHook(lpparam.classLoader))
+                    startHook(VideoSubtitleHook(lpparam.classLoader))
                 }
                 lpparam.processName.endsWith(":web") -> {
                     BiliBiliPackage(lpparam.classLoader, param.args[0] as Context)

--- a/app/src/main/java/me/iacn/biliroaming/hook/VideoSubtitleHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/VideoSubtitleHook.kt
@@ -1,0 +1,67 @@
+package me.iacn.biliroaming.hook
+
+import android.net.Uri
+import me.iacn.biliroaming.API
+import me.iacn.biliroaming.copy
+import me.iacn.biliroaming.subtitleItem
+import me.iacn.biliroaming.utils.*
+import java.lang.reflect.Method
+
+class VideoSubtitleHook(classLoader: ClassLoader) : BaseHook(classLoader) {
+
+    private val convertApi = "https://www.kofua.top/bsub/%s"
+
+    override fun startHook() {
+        if (!sPrefs.getBoolean("auto_generate_subtitle", false)) return
+
+        "com.bapis.bilibili.community.service.dm.v1.DMMoss".from(mClassLoader)
+            ?.hookAfterMethod(
+                "dmView",
+                "com.bapis.bilibili.community.service.dm.v1.DmViewReq"
+            ) { param ->
+                val dmViewReply = param.result?.let {
+                    API.DmViewReply.parseFrom(
+                        it.callMethodAs<ByteArray>("toByteArray")
+                    )
+                } ?: return@hookAfterMethod
+                val subtitles = dmViewReply.subtitle.subtitlesList
+                if (subtitles.isEmpty()) return@hookAfterMethod
+                val lanCodes = subtitles.map { it.lan }
+                val genCN = "zh-Hant" in lanCodes && "zh-CN" !in lanCodes
+                val genHant = "zh-CN" in lanCodes && "zh-Hant" !in lanCodes
+                val origin = if (genCN) "zh-Hant" else if (genHant) "zh-CN" else ""
+                val target = if (genCN) "zh-CN" else if (genHant) "zh-Hant" else ""
+                val converter = if (genCN) "t2cn" else if (genHant) "cn2t" else ""
+                val targetDoc = if (genCN) "简中（生成）" else if (genHant) "繁中（生成）" else ""
+                val targetDocBrief = if (genCN) "简中" else if (genHant) "繁中" else ""
+                if (origin.isEmpty()) return@hookAfterMethod
+
+                val origSub = subtitles.first { it.lan == origin }
+                var origSubId = origSub.id
+                val targetSubUrl = Uri.parse(convertApi.format(converter))
+                    .buildUpon()
+                    .appendQueryParameter("sub_url", origSub.subtitleUrl)
+                    .appendQueryParameter("sub_id", origSubId.toString())
+                    .build()
+                    .toString()
+
+                val newSub = subtitleItem {
+                    lan = target
+                    lanDoc = targetDoc
+                    lanDocBrief = targetDocBrief
+                    subtitleUrl = targetSubUrl
+                    id = ++origSubId
+                    idStr = origSubId.toString()
+                }
+
+                val newRes = dmViewReply.copy {
+                    subtitle = subtitle.copy {
+                        this.subtitles.add(newSub)
+                    }
+                }
+
+                param.result = (param.method as Method).returnType
+                    .callStaticMethod("parseFrom", newRes.toByteArray())
+            }
+    }
+}

--- a/app/src/main/proto/me/iacn/biliroaming/api.proto
+++ b/app/src/main/proto/me/iacn/biliroaming/api.proto
@@ -446,6 +446,8 @@ message SubtitleItem {
   optional string lan_doc = 0x4;
   optional string subtitle_url = 0x5;
   optional UserInfo author = 0x6;
+  optional int32 type = 0x7;
+  optional string lan_doc_brief = 0x8;
 }
 
 message VideoSubtitle {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -176,4 +176,6 @@
     <string name="custom_link_summary">仅支持 bilibili:// 开头的格式</string>
     <string name="add_custom_button_title">在【我的】页面添加自定义按钮</string>
     <string name="add_custom_button_summary">指定修改其中一个项目</string>
+    <string name="auto_generate_subtitle_title">互转简繁字幕</string>
+    <string name="auto_generate_subtitle_summary">为简繁字幕生成相应的繁简字幕\nPowered by 繁化姬</string>
 </resources>

--- a/app/src/main/res/xml/prefs_setting.xml
+++ b/app/src/main/res/xml/prefs_setting.xml
@@ -279,6 +279,11 @@
             android:key="block_upper_recommend_ad"
             android:summary="@string/block_video_ad_summary"
             android:title="@string/block_video_ad_title" />
+        <SwitchPreference
+            android:dependency="hidden"
+            android:key="auto_generate_subtitle"
+            android:summary="@string/auto_generate_subtitle_summary"
+            android:title="@string/auto_generate_subtitle_title" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
字幕转换接口目前也稳定运行两个多月了，从各公共解析服务器数据来看，漫游用户大致是脚本用户的4-5倍，目前脚本每天的处理量大致在10000左右，到繁化姬转换的量在100以内，按照目前的用户体量，服务器是能保证正常运行的，故可以考虑合并此pr。
另，现在我在字幕附加了禁止宣传的信息，可以一定程度上减少用户在站内的宣传行为。
![image](https://user-images.githubusercontent.com/10793522/162773781-6a7b15be-34cc-4ca1-bced-b54ed925927b.png)
