### PR TITLE
默认开启 修复UP主空间 功能

### DIFF
--- a/app/src/main/res/xml/prefs_setting.xml
+++ b/app/src/main/res/xml/prefs_setting.xml
@@ -130,6 +130,7 @@
             android:title="@string/custom_link_title" />
 
         <SwitchPreference
+            android:defaultValue="true"
             android:key="fix_space"
             android:summary="@string/fix_space_summary"
             android:title="@string/fix_space_title" />


### PR DESCRIPTION
在过去的版本中，出差账号默认修复，无需开启任何开关。
而在 fix_space 这一提交之后，需要开启开关才可修复出差账号。可以预想到，正式版发布后肯定会有若干人提问“为什么更新之后出差打不开了”之类的问题。
并且此功能开启选项位置偏后，也有部分新用户注意不到这个选项（或者不知道出差账户也是受限的）