### PR TITLE
Allow to disable player long click to accelerate

### DIFF
--- a/app/src/main/java/me/iacn/biliroaming/XposedInit.kt
+++ b/app/src/main/java/me/iacn/biliroaming/XposedInit.kt
@@ -113,6 +113,7 @@ class XposedInit : IXposedHookLoadPackage, IXposedHookZygoteInit {
                     startHook(StartActivityHook(lpparam.classLoader))
                     startHook(FullStoryHook(lpparam.classLoader))
                     startHook(DialogBlurBackgroundHook(lpparam.classLoader))
+                    startHook(PlayerLongPressHook(lpparam.classLoader))
                 }
                 lpparam.processName.endsWith(":web") -> {
                     BiliBiliPackage(lpparam.classLoader, param.args[0] as Context)

--- a/app/src/main/java/me/iacn/biliroaming/hook/PlayerLongPressHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/PlayerLongPressHook.kt
@@ -1,43 +1,31 @@
 package me.iacn.biliroaming.hook
 
 import android.view.MotionEvent
-import de.robv.android.xposed.XC_MethodReplacement
-import de.robv.android.xposed.XposedBridge
-import de.robv.android.xposed.XposedHelpers
+import me.iacn.biliroaming.utils.Hooker
+import me.iacn.biliroaming.utils.Log
+import me.iacn.biliroaming.utils.hookBeforeMethod
 import me.iacn.biliroaming.utils.sPrefs
 
 class PlayerLongPressHook(classLoader: ClassLoader) : BaseHook(classLoader) {
-
-    private val enabled = sPrefs.getBoolean("forbid_player_long_click_accelerate", false)
-
-    private val replacement = object : XC_MethodReplacement() {
-        override fun replaceHookedMethod(param: MethodHookParam): Any = true
-    }
-
     override fun startHook() {
-        if(!enabled) return
-        //6.59.0以前
-        val className = "tv.danmaku.biliplayerimpl.gesture" +
-                ".GestureService\$mTouchListener\$1"
-        var clazz = XposedHelpers.findClass(className, mClassLoader)
-        XposedHelpers.findAndHookMethod(clazz, "onLongPress",
-                MotionEvent::class.java, replacement)
-        //6.59.0
-        val classNames = arrayOf(
-                "tv.danmaku.biliplayerimpl.gesture.GestureService\$" +
-                        "initInnerLongPressListener\$1\$onLongPress\$1",
-                "tv.danmaku.biliplayerimpl.gesture.GestureService\$" +
-                        "initInnerLongPressListener\$1\$onLongPressEnd\$1"
+        if (!sPrefs.getBoolean("forbid_player_long_click_accelerate", false)) return
+
+        Log.d("startHook: PlayerLongPress");
+
+        val hooker: Hooker = { param -> param.result = true }
+        // pre 6.59.0
+        "tv.danmaku.biliplayerimpl.gesture.GestureService\$mTouchListener\$1".hookBeforeMethod(
+            mClassLoader,
+            "onLongPress",
+            MotionEvent::class.java,
+            hooker = hooker
         )
-        classNames.forEach outer@{
-            clazz = XposedHelpers.findClassIfExists(it, mClassLoader)
-            clazz?.declaredMethods?.forEach inner@{ method ->
-                if(method.name != "invoke") return@inner
-                if(method.returnType == java.lang.Boolean::class.java ||
-                   method.returnType == java.lang.Boolean::class.javaPrimitiveType) {
-                    XposedBridge.hookMethod(method, replacement)
-                }
-            }
+        // post 6.59.0
+        arrayOf(
+            "tv.danmaku.biliplayerimpl.gesture.GestureService\$initInnerLongPressListener\$1\$onLongPress\$1",
+            "tv.danmaku.biliplayerimpl.gesture.GestureService\$initInnerLongPressListener\$1\$onLongPressEnd\$1"
+        ).forEach { className ->
+            className.hookBeforeMethod(mClassLoader, "invoke", Object::class.java, hooker = hooker)
         }
     }
 }

--- a/app/src/main/java/me/iacn/biliroaming/hook/PlayerLongPressHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/PlayerLongPressHook.kt
@@ -1,0 +1,91 @@
+package me.iacn.biliroaming.hook
+
+import de.robv.android.xposed.XC_MethodReplacement
+import de.robv.android.xposed.XposedBridge
+import me.iacn.biliroaming.utils.sPrefs
+import java.lang.reflect.Method
+
+class PlayerLongPressHook(classLoader: ClassLoader) : BaseHook(classLoader) {
+
+    private val replacement: XC_MethodReplacement =
+            object : XC_MethodReplacement() {
+
+        override fun replaceHookedMethod(param: MethodHookParam): Any {
+            if(sPrefs.getBoolean("forbid_player_long_click_accelerate", false)) {
+                return true
+            }
+            return XposedBridge.invokeOriginalMethod(param.method,
+                    param.thisObject, param.args)
+        }
+    }
+
+    override fun startHook() {
+        replace1()
+        replace2()
+    }
+
+    private inline fun doIgnoreException(action: () -> Unit) {
+        try {
+            action()
+        } catch(t: Throwable) {
+            //ignore
+        }
+    }
+
+    private fun findMethod(clazz: Class<*>, methodName: String): Method? {
+        for(method in clazz.declaredMethods) {
+            if(method.name == methodName) return method
+        }
+        return null
+    }
+
+    private fun classNameListToClassList(vararg classNameList: String):
+            List<Class<*>> {
+        val classes = ArrayList<Class<*>>()
+        classNameList.forEach {
+            classes.add(mClassLoader.loadClass(it))
+        }
+        return classes
+    }
+
+    private fun hookInvokeMethod(vararg classNameList: String) {
+        doIgnoreException {
+            for(aClass in classNameListToClassList(*classNameList)) {
+                for(method in aClass.declaredMethods) {
+                    if(method.name != "invoke") continue
+                    if(method.returnType == java.lang.Boolean::class.java ||
+                            method.returnType == java.lang.Boolean::class
+                                    .javaPrimitiveType) {
+                        XposedBridge.hookMethod(method, replacement)
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * 6.59.0以前
+     */
+    private fun replace1() {
+        val className = "tv.danmaku.biliplayerimpl.gesture" +
+                ".GestureService\$mTouchListener\$1"
+        doIgnoreException {
+            val clazz: Class<*> = mClassLoader.loadClass(className)
+            val method: Method = findMethod(clazz, "onLongPress")!!
+            XposedBridge.hookMethod(method, replacement)
+        }
+    }
+
+    /**
+     * 6.59.0
+     */
+    private fun replace2() {
+        val classeNames = arrayOf(
+                "tv.danmaku.biliplayerimpl.gesture.GestureService" +
+                        "\$initInnerLongPressListener\$1\$onLongPress\$1",
+                "tv.danmaku.biliplayerimpl.gesture.GestureService" +
+                        "\$initInnerLongPressListener\$1\$onLongPressEnd\$1"
+        )
+        hookInvokeMethod(*classeNames)
+    }
+}

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -229,4 +229,6 @@
     <string name="generate_subtitle_summary">根據繁體字幕自動生成簡體中文字幕</string>
     <string name="forbid_switch_live_room_title">禁止滑動切換直播間</string>
     <string name="forbid_switch_live_room_summary">禁止上下滑動切換直播間</string>
+    <string name="forbid_player_long_click_accelerate_title">禁用播放器長按加速</string>
+    <string name="forbid_player_long_click_accelerate_summary">禁用播放器長按開啟倍速播放的功能</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,4 +229,6 @@
     <string name="generate_subtitle_summary">根据繁体字幕自动生成简体中文字幕</string>
     <string name="forbid_switch_live_room_title">禁止滑动切换直播间</string>
     <string name="forbid_switch_live_room_summary">禁止上下滑动切换直播间</string>
+    <string name="forbid_player_long_click_accelerate_title">禁用播放器长按加速</string>
+    <string name="forbid_player_long_click_accelerate_summary">禁用播放器长按开启倍速播放的功能</string>
 </resources>

--- a/app/src/main/res/xml/prefs_setting.xml
+++ b/app/src/main/res/xml/prefs_setting.xml
@@ -170,6 +170,10 @@
             android:summary="@string/forbid_switch_live_room_summary"
             android:title="@string/forbid_switch_live_room_title" />
 
+        <SwitchPreference
+            android:key="forbid_player_long_click_accelerate"
+            android:summary="@string/forbid_player_long_click_accelerate_summary"
+            android:title="@string/forbid_player_long_click_accelerate_title" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_backup">
         <Preference


### PR DESCRIPTION
在通过播放器主界面**微调**进度时，极易误触发长按加速，播放器编辑界面无关闭长按加速的选项。
若无长按加速播放的需求，可通过此法禁用此功能。