### PR TITLE
Restore danmaku weight filter

### DIFF
--- a/app/src/main/java/me/iacn/biliroaming/SettingDialog.kt
+++ b/app/src/main/java/me/iacn/biliroaming/SettingDialog.kt
@@ -21,6 +21,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.EditText
+import android.widget.Switch
 import android.widget.TextView
 import androidx.documentfile.provider.DocumentFile
 import kotlinx.coroutines.MainScope
@@ -77,6 +78,7 @@ class SettingDialog(context: Context) : AlertDialog.Builder(context) {
             findPreference("export_video")?.onPreferenceClickListener = this
             findPreference("home_filter")?.onPreferenceClickListener = this
             findPreference("custom_subtitle")?.onPreferenceChangeListener = this
+            findPreference("danmaku_filter")?.onPreferenceChangeListener = this
             findPreference("customize_accessKey")?.onPreferenceClickListener = this
             findPreference("share_log")?.onPreferenceClickListener = this
             findPreference("customize_drawer")?.onPreferenceClickListener = this
@@ -229,6 +231,12 @@ class SettingDialog(context: Context) : AlertDialog.Builder(context) {
                     if (newValue as Boolean)
                         onAddCustomButtonClick()
                 }
+                "danmaku_filter" -> {
+                    if (newValue as Boolean) {
+                        onDanmakuFilterClick()
+                    }
+                }
+
             }
             return true
         }
@@ -373,6 +381,63 @@ class SettingDialog(context: Context) : AlertDialog.Builder(context) {
                     val intent = Intent(Intent.ACTION_VIEW, uri)
                     startActivity(intent)
                 }
+                show()
+            }
+            return true
+        }
+
+
+        private fun onDanmakuFilterClick(): Boolean {
+            AlertDialog.Builder(activity).run {
+                val layout = moduleRes.getLayout(R.layout.danmaku_filter_dialog)
+                val inflater = LayoutInflater.from(context)
+                val view = inflater.inflate(layout, null)
+                val editTexts = arrayOf(
+                    view.findViewById<EditText>(R.id.danmaku_filter_weight_value)!!,
+                )
+                val switches = arrayOf(
+                    view.findViewById<Switch>(R.id.danmaku_filter_weight_switch),
+                )
+                val switchPairs = listOf<Pair<Switch, EditText>>(Pair(switches[0], editTexts[0]))
+
+                editTexts.forEach {
+                    it.setText(
+                        prefs.getString(
+                            it.tag.toString(),
+                            it.hint.toString()
+                        )
+                    )
+                }
+                switches.forEach {
+                    if (prefs.contains(it.tag.toString())) {
+                        it.isChecked = prefs.getBoolean(it.tag.toString(), false)
+                    }
+                }
+
+                switchPairs.forEach {
+                    it.second.alpha = if (it.first.isChecked) 1f else 0.2f
+                    it.first.setOnCheckedChangeListener { _, isChecked ->
+                        it.second.alpha = if (isChecked) 1f else 0.2f
+                    }
+                }
+
+                setPositiveButton(android.R.string.ok) { _, _ ->
+                    editTexts.forEach {
+                        val host = it.text.toString()
+                        if (host.isNotEmpty())
+                            prefs.edit().putString(
+                                it.tag.toString(),
+                                host
+                            ).apply()
+                        else
+                            prefs.edit().remove(it.tag.toString()).apply()
+                    }
+                    switches.forEach {
+                        prefs.edit().putBoolean(it.tag.toString(), it.isChecked).apply()
+                    }
+                }
+                setTitle("弹幕屏蔽设置")
+                setView(view)
                 show()
             }
             return true

--- a/app/src/main/java/me/iacn/biliroaming/XposedInit.kt
+++ b/app/src/main/java/me/iacn/biliroaming/XposedInit.kt
@@ -115,6 +115,7 @@ class XposedInit : IXposedHookLoadPackage, IXposedHookZygoteInit {
                     startHook(VipSectionHook(lpparam.classLoader))
                     startHook(CommentImageHook(lpparam.classLoader))
                     startHook(WebViewHook(lpparam.classLoader))
+                    startHook(DanmakuHook(lpparam.classLoader))
                 }
 
                 lpparam.processName.endsWith(":web") -> {

--- a/app/src/main/java/me/iacn/biliroaming/hook/DanmakuHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/DanmakuHook.kt
@@ -1,0 +1,77 @@
+package me.iacn.biliroaming.hook
+
+import me.iacn.biliroaming.utils.*
+
+
+class DanmakuHook(classLoader: ClassLoader) : BaseHook(classLoader) {
+
+    val MossException = "com.bilibili.lib.moss.api.MossException".findClass(mClassLoader)
+
+    override fun startHook() {
+        if (!sPrefs.getBoolean("danmaku_filter", false)) {
+            return
+        }
+        Log.d("StartHook: DanmakuHook")
+        danmakuHook()
+    }
+
+
+    fun danmakuHook() {
+        "com.bapis.bilibili.community.service.dm.v1.DMMoss".findClass(mClassLoader).let {
+            Log.d("DanmakuHook: hook $it")
+            it.hookBeforeMethod(
+                "dmSegMobile",
+                "com.bapis.bilibili.community.service.dm.v1.DmSegMobileReq",
+                "com.bilibili.lib.moss.api.MossResponseHandler"
+            ) { methodHookParam ->
+                try {
+                    methodHookParam.thisObject.callMethod(
+                        "dmSegMobile", methodHookParam.args[0]
+                    )
+                } catch (e: Throwable) {
+                    methodHookParam.args[1].callMethod(
+                        "onError", MossException.getStaticObjectField("UNSUPPORTED")
+                    )
+                    null
+                }?.let { dmSegMobileReply ->
+                    methodHookParam.args[1].callMethod("onNext", dmSegMobileReply)
+                }
+                methodHookParam.result = null
+            }
+            it.hookAfterMethod(
+                "dmSegMobile", "com.bapis.bilibili.community.service.dm.v1.DmSegMobileReq"
+            ) { methodHookParam ->
+                Log.d("DanmakuHook: call " + methodHookParam.method.name)
+                try {
+                    filterDanmaku(methodHookParam.result)
+                } catch (e: Throwable) {
+                    println(e)
+                    methodHookParam.throwable =
+                        MossException.getStaticObjectField("UNSUPPORTED") as Throwable?
+                }
+            }
+        }
+    }
+
+
+    fun filterDanmaku(dmSegmentMobileReply: Any) {
+        val resultDanmakuList = mutableListOf<Any>()
+        val weightThreshold = if (sPrefs.getBoolean(
+                "danmaku_filter_weight_switch", false
+            )
+        ) sPrefs.getString("danmaku_filter_weight_value", "0")?.toInt() else null
+        Log.d("DanmakuHook: weightThreshold" + weightThreshold)
+        for (danmakuElem in (dmSegmentMobileReply.getObjectField("elems_") as List<*>)) {
+            if (danmakuElem != null) {
+                if (weightThreshold != null) {
+                    val weight = danmakuElem.callMethod("getWeight") as Int
+                    if (weight < weightThreshold) continue
+                }
+                resultDanmakuList.add(danmakuElem)
+            }
+        }
+        Log.d("DanmakuHook: before= " + dmSegmentMobileReply.callMethod("getElemsCount") + " ;after=" + resultDanmakuList.size)
+        dmSegmentMobileReply.callMethod("clearElems")
+        dmSegmentMobileReply.callMethod("addAllElems", resultDanmakuList)
+    }
+}

--- a/app/src/main/res/layout/danmaku_filter_dialog.xml
+++ b/app/src/main/res/layout/danmaku_filter_dialog.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GridLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:columnCount="2"
+    android:orientation="horizontal"
+    android:paddingStart="25dp"
+    android:paddingEnd="20dp"
+    android:rowCount="6">
+
+
+    <TextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_columnWeight="4"
+        android:text="弹幕云屏蔽等级"
+        tools:ignore="HardcodedText" />
+
+    <Switch
+        android:id="@+id/danmaku_filter_weight_switch"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_columnWeight="1"
+        android:checked="true"
+        android:tag="danmaku_filter_weight_switch"
+        tools:ignore="HardcodedText" />
+
+    <TextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_columnWeight="2"
+        android:singleLine="true"
+        android:text="弹幕屏蔽等级"
+        tools:ignore="HardcodedText" />
+
+    <EditText
+        android:id="@+id/danmaku_filter_weight_value"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_columnWeight="5"
+        android:autofillHints="no"
+        android:hint="4"
+        android:inputType="numberDecimal"
+        android:tag="danmaku_filter_weight_value"
+        tools:ignore="HardcodedText" />
+
+
+</GridLayout>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -269,4 +269,7 @@
     <string name="remove_vip_section_summary">我的頁面將大會員橫幅移除</string>
     <string name="save_comment_image_title">筆記圖片長按儲存</string>
     <string name="save_comment_image_summary">影片筆記圖片長按儲存到本地</string>
+
+    <string name="danmaku_filter_summary">彈幕屏蔽優化</string>
+    <string name="danmaku_filter_title">增强彈幕屏蔽功能</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -269,4 +269,7 @@
     <string name="remove_vip_section_summary">我的页面将大会员横幅移除</string>
     <string name="save_comment_image_title">笔记图片长按保存</string>
     <string name="save_comment_image_summary">视频笔记图片长按保存到本地</string>
+
+    <string name="danmaku_filter_summary">弹幕屏蔽优化</string>
+    <string name="danmaku_filter_title">增强弹幕屏蔽功能</string>
 </resources>

--- a/app/src/main/res/xml/prefs_setting.xml
+++ b/app/src/main/res/xml/prefs_setting.xml
@@ -155,6 +155,11 @@
             android:title="@string/play_arc_conf_title" />
 
         <SwitchPreference
+            android:key="danmaku_filter"
+            android:summary="@string/danmaku_filter_summary"
+            android:title="@string/danmaku_filter_title" />
+
+        <SwitchPreference
             android:defaultValue="false"
             android:key="force_browser"
             android:summary="@string/force_browser_summary"


### PR DESCRIPTION

#981 恢复旧版弹幕云屏蔽功能
弹幕云屏蔽目前在网页端中仍被正常维护,其参数随DmSegMobileReply返回,已有至少3年没有变动,应该较为稳定.
该功能经测试在6.9.1, 6.72, 6.89, 7.21.0可正常使用,在6.49-6.56中失效.
后续可能可以扩展该功能, 实现类似pakku.js的智能合并.