### PR TITLE
Fix get current area info

### DIFF
--- a/app/src/main/java/me/iacn/biliroaming/Constant.kt
+++ b/app/src/main/java/me/iacn/biliroaming/Constant.kt
@@ -24,5 +24,6 @@ object Constant {
     const val CURRENT_COLOR_KEY = "theme_entries_current_key"
     const val DEFAULT_CUSTOM_COLOR = -0xe6b7d
     const val infoUrl = "https://api.bilibili.com/client_info"
+    const val zoneUrl = "https://api.bilibili.com/x/web-interface/zone"
     val HOST_REGEX = Regex(""":\\?/\\?/([^/]+)\\?/""")
 }

--- a/app/src/main/java/me/iacn/biliroaming/XposedInit.kt
+++ b/app/src/main/java/me/iacn/biliroaming/XposedInit.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.future.future
 import me.iacn.biliroaming.hook.*
 import me.iacn.biliroaming.utils.*
+import org.json.JSONObject
 import java.util.concurrent.CompletableFuture
 
 
@@ -68,8 +69,13 @@ class XposedInit : IXposedHookLoadPackage, IXposedHookZygoteInit {
                     )
 
                     country = MainScope().future(Dispatchers.IO) {
+                        fun JSONObject.optStringFix(name: String, fallback: String = "") =
+                            if (isNull(name)) fallback else optString(name, fallback)
                         when (fetchJson(Constant.infoUrl)?.optJSONObject("data")
-                            ?.optString("country")) {
+                            ?.optStringFix("country").orEmpty().ifEmpty {
+                                fetchJson(Constant.zoneUrl)?.optJSONObject("data")
+                                    ?.optStringFix("country")
+                            }) {
                             "中国" -> "cn"
                             "香港", "澳门" -> "hk"
                             "台湾" -> "tw"


### PR DESCRIPTION
`client_info` 接口某些网络下有可能拿不到 IP 地理位置信息，进而导致测速失败等问题，`zone` 接口作为备用手段。