### PR TITLE
Allow remember lossless setting switch state

### DIFF
--- a/app/src/main/java/me/iacn/biliroaming/XposedInit.kt
+++ b/app/src/main/java/me/iacn/biliroaming/XposedInit.kt
@@ -125,6 +125,7 @@ class XposedInit : IXposedHookLoadPackage, IXposedHookZygoteInit {
                     startHook(DanmakuHook(lpparam.classLoader))
                     startHook(BangumiPageAdHook(lpparam.classLoader))
                     startHook(VideoQualityHook(lpparam.classLoader))
+                    startHook(LosslessSettingHook(lpparam.classLoader))
                 }
 
                 lpparam.processName.endsWith(":web") -> {

--- a/app/src/main/java/me/iacn/biliroaming/hook/CustomThemeHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/CustomThemeHook.kt
@@ -1,8 +1,5 @@
 package me.iacn.biliroaming.hook
 
-import android.app.AndroidAppHelper
-import android.content.Context
-import android.content.SharedPreferences
 import android.graphics.Color
 import android.util.SparseArray
 import android.view.View
@@ -159,11 +156,6 @@ class CustomThemeHook(classLoader: ClassLoader) : BaseHook(classLoader) {
     companion object {
         private const val CUSTOM_THEME_ID1 = 114514 // ん？
         private const val CUSTOM_THEME_ID2 = 1919810 // ん？
-
-        @Suppress("DEPRECATION")
-        private val biliPrefs: SharedPreferences
-            get() = AndroidAppHelper.currentApplication()
-                .getSharedPreferences("bili_preference", Context.MODE_MULTI_PROCESS)
 
         private var customColor: Int
             get() = biliPrefs.getInt(CUSTOM_COLOR_KEY, DEFAULT_CUSTOM_COLOR)

--- a/app/src/main/java/me/iacn/biliroaming/hook/LosslessSettingHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/LosslessSettingHook.kt
@@ -1,0 +1,60 @@
+package me.iacn.biliroaming.hook
+
+import me.iacn.biliroaming.BiliBiliPackage.Companion.instance
+import me.iacn.biliroaming.utils.*
+
+class LosslessSettingHook(classLoader: ClassLoader) : BaseHook(classLoader) {
+    private var losslessEnabled: Boolean
+        get() = biliPrefs.getBoolean("biliroaming_lossless", false)
+        set(value) {
+            biliPrefs.edit().putBoolean("biliroaming_lossless", value).apply()
+        }
+
+    override fun startHook() {
+        if (!sPrefs.getBoolean("remember_lossless_setting", false))
+            return
+        instance.playURLMossClass?.run {
+            hookBeforeMethod(
+                "playConf",
+                "com.bapis.bilibili.app.playurl.v1.PlayConfReq",
+                instance.mossResponseHandlerClass
+            ) { param ->
+                param.args[1] = param.args[1].mossResponseHandlerProxy {
+                    it?.callMethod("getPlayConf")
+                        ?.callMethod("getLossLessConf")
+                        ?.callMethod("getConfValue")
+                        ?.callMethod("setSwitchVal", losslessEnabled)
+                }
+            }
+            hookBeforeMethod(
+                "playConfEdit",
+                "com.bapis.bilibili.app.playurl.v1.PlayConfEditReq"
+            ) { param ->
+                param.args[0].callMethodAs<List<Any>>("getPlayConfList")
+                    .firstOrNull {
+                        it.callMethodAs<Int>("getConfTypeValue") == 30 // LOSSLESS
+                    }?.callMethod("getConfValue")
+                    ?.callMethodAs<Boolean>("getSwitchVal")
+                    ?.let { losslessEnabled = it }
+            }
+            hookAfterMethod(
+                "playView", instance.playViewReqClass
+            ) { param ->
+                param.result?.callMethod("getPlayConf")
+                    ?.takeIf { it.callMethodAs("hasLossLessConf") }
+                    ?.callMethod("getLossLessConf")
+                    ?.callMethod("getConfValue")
+                    ?.callMethod("setSwitchVal", losslessEnabled)
+            }
+        }
+        instance.playerMossClass?.hookAfterMethod(
+            "playViewUnite", instance.playViewUniteReqClass
+        ) { param ->
+            param.result?.callMethod("getPlayDeviceConf")
+                ?.callMethodAs<LinkedHashMap<Int, *>>("internalGetMutableDeviceConfs")?.let {
+                    it[30/*LOSSLESS*/]?.callMethod("getConfValue")
+                        ?.callMethod("setSwitchVal", losslessEnabled)
+                }
+        }
+    }
+}

--- a/app/src/main/java/me/iacn/biliroaming/utils/Utils.kt
+++ b/app/src/main/java/me/iacn/biliroaming/utils/Utils.kt
@@ -3,6 +3,7 @@ package me.iacn.biliroaming.utils
 import android.annotation.SuppressLint
 import android.app.AndroidAppHelper
 import android.content.Context
+import android.content.SharedPreferences
 import android.content.pm.PackageManager.GET_META_DATA
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
@@ -114,12 +115,16 @@ val logFile by lazy { File(currentContext.externalCacheDir, "log.txt") }
 val oldLogFile by lazy { File(currentContext.externalCacheDir, "old_log.txt") }
 
 @Suppress("DEPRECATION")
-val sPrefs
-    get() = currentContext.getSharedPreferences("biliroaming", Context.MODE_MULTI_PROCESS)!!
+val sPrefs: SharedPreferences
+    get() = currentContext.getSharedPreferences("biliroaming", Context.MODE_MULTI_PROCESS)
 
 @Suppress("DEPRECATION")
-val sCaches
-    get() = currentContext.getSharedPreferences("biliroaming_cache", Context.MODE_MULTI_PROCESS)!!
+val sCaches: SharedPreferences
+    get() = currentContext.getSharedPreferences("biliroaming_cache", Context.MODE_MULTI_PROCESS)
+
+@Suppress("DEPRECATION")
+val biliPrefs: SharedPreferences
+    get() = currentContext.getSharedPreferences("bili_preference", Context.MODE_MULTI_PROCESS)
 
 fun checkErrorToast(json: JSONObject, isCustomServer: Boolean = false) {
     if (json.optInt("code", 0) != 0) {

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -255,4 +255,6 @@
     <string name="full_screen_quality_summary">設定影片全螢幕播放時預設的清晰度，當播放器畫質選項為自動時此選項不生效，需開啟解鎖番劇限制選項</string>
     <string name="block_comment_guide_title">封鎖評論引導</string>
     <string name="block_comment_guide_summary">封鎖影片詳情頁及評論頁的評論引導提示</string>
+    <string name="remember_lossless_setting_title">記住無損設置開關狀態</string>
+    <string name="remember_lossless_setting_summary">記住播放器無損設置開關狀態</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -255,4 +255,6 @@
     <string name="full_screen_quality_summary">设置视频全屏播放时默认的清晰度，当播放器画质选项为自动时此选项不生效，需开启解锁番剧限制选项</string>
     <string name="block_comment_guide_title">屏蔽评论引导</string>
     <string name="block_comment_guide_summary">屏蔽视频详情页及评论页的评论引导提示</string>
+    <string name="remember_lossless_setting_title">记住无损设置开关状态</string>
+    <string name="remember_lossless_setting_summary">记住播放器无损设置开关状态</string>
 </resources>

--- a/app/src/main/res/xml/prefs_setting.xml
+++ b/app/src/main/res/xml/prefs_setting.xml
@@ -221,6 +221,11 @@
             android:key="block_comment_guide"
             android:summary="@string/block_comment_guide_summary"
             android:title="@string/block_comment_guide_title" />
+
+        <SwitchPreference
+            android:key="remember_lossless_setting"
+            android:summary="@string/remember_lossless_setting_summary"
+            android:title="@string/remember_lossless_setting_title" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_backup">
         <Preference


### PR DESCRIPTION
无损开关状态是上传至服务器的，但阿B故意不下发（杜比音效设置开关就会下发），但我们可以本地处理，让开关状态在APP安装周期内记住。