### PR TITLE
fix: 7.41.0 compatibility

### DIFF
--- a/app/src/main/java/me/iacn/biliroaming/BiliBiliPackage.kt
+++ b/app/src/main/java/me/iacn/biliroaming/BiliBiliPackage.kt
@@ -151,6 +151,8 @@ class BiliBiliPackage constructor(private val mClassLoader: ClassLoader, mContex
     val playViewUniteReqClass by Weak { "com.bapis.bilibili.app.playerunite.v1.PlayViewUniteReq" from mClassLoader }
     val viewMossClass by Weak { "com.bapis.bilibili.app.view.v1.ViewMoss" from mClassLoader }
     val viewReqClass by Weak { "com.bapis.bilibili.app.view.v1.ViewReq" from mClassLoader }
+    val viewUniteMossClass by Weak { "com.bapis.bilibili.app.viewunite.v1.ViewMoss" from mClassLoader }
+    val viewUniteReqClass by Weak { "com.bapis.bilibili.app.viewunite.v1.ViewReq" from mClassLoader }
     val bkArcPartClass by Weak { "com.bapis.bilibili.app.listener.v1.BKArcPart" from mClassLoader }
     val builtInThemesClass by Weak { mHookInfo.builtInThemes.class_ from mClassLoader }
     val themeColorsConstructor by Weak {

--- a/app/src/main/java/me/iacn/biliroaming/BiliBiliPackage.kt
+++ b/app/src/main/java/me/iacn/biliroaming/BiliBiliPackage.kt
@@ -162,6 +162,7 @@ class BiliBiliPackage constructor(private val mClassLoader: ClassLoader, mContex
     }
     val biliGlobalPreferenceClass by Weak { mHookInfo.biliGlobalPreference.class_ from mClassLoader }
     val dmMossClass by Weak { "com.bapis.bilibili.community.service.dm.v1.DMMoss" from mClassLoader }
+    val dmViewReqClass by Weak { "com.bapis.bilibili.community.service.dm.v1.DmViewReq" from mClassLoader }
     val treePointItemClass by Weak { "com.bilibili.app.comm.list.common.data.ThreePointItem" from mClassLoader }
     val dislikeReasonClass by Weak { "com.bilibili.app.comm.list.common.data.DislikeReason" from mClassLoader }
     val cardClickProcessorClass by Weak { mHookInfo.cardClickProcessor.class_ from mClassLoader }

--- a/app/src/main/java/me/iacn/biliroaming/BiliBiliPackage.kt
+++ b/app/src/main/java/me/iacn/biliroaming/BiliBiliPackage.kt
@@ -1509,8 +1509,8 @@ class BiliBiliPackage constructor(private val mClassLoader: ClassLoader, mContex
             commentSpan = class_ {
                 name = commentSpanClass?.name ?: return@class_
             }
+            val viewIndex = dexHelper.encodeClassIndex(View::class.java)
             commentLongClick = class_ {
-                val viewIndex = dexHelper.encodeClassIndex(View::class.java)
                 val onLongClickListenerIndex = dexHelper.encodeMethodIndex(
                     View::class.java.getDeclaredMethod(
                         "setOnLongClickListener",
@@ -1668,7 +1668,6 @@ class BiliBiliPackage constructor(private val mClassLoader: ClassLoader, mContex
                     null,
                     true
                 ).firstOrNull() ?: return@descCopy
-                val viewIndex = dexHelper.encodeClassIndex(View::class.java)
                 val clickableSpanIndex = dexHelper.encodeClassIndex(ClickableSpan::class.java)
                 dexHelper.findMethodInvoked(
                     toCopyMethodIndex,
@@ -1688,14 +1687,9 @@ class BiliBiliPackage constructor(private val mClassLoader: ClassLoader, mContex
                 }
                 classesList.filter {
                     it.startsWith("com.bilibili.ship.theseus.ugc.intro.ugcheadline.UgcIntroductionComponent")
-                }.map {
-                    it.on(classloader)
-                }.flatMap { c ->
+                }.map { it.on(classloader) }.flatMap { c ->
                     c.declaredMethods.filter {
-                        it.isPublic
-                                && it.parameterCount == 2
-                                && it.parameterTypes[0] == View::class.java
-                                && it.parameterTypes[1] == ClickableSpan::class.java
+                        it.isPublic && it.parameterCount == 2 && it.parameterTypes[0] == View::class.java && it.parameterTypes[1] == ClickableSpan::class.java
                     }
                 }.forEach {
                     classes += class_ { name = it.declaringClass.name }

--- a/app/src/main/java/me/iacn/biliroaming/hook/BangumiPageAdHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/BangumiPageAdHook.kt
@@ -5,7 +5,7 @@ import me.iacn.biliroaming.utils.*
 
 class BangumiPageAdHook(classLoader: ClassLoader) : BaseHook(classLoader) {
     override fun startHook() {
-        if (!sPrefs.getBoolean("block_bangumi_page_ads", false)) return
+        if (!sPrefs.getBoolean("block_view_page_ads", false)) return
         Log.d("startHook: BangumiPageAd")
         // activity toast ad
         "com.bilibili.bangumi.data.page.detail.entity.OGVActivityVo".from(mClassLoader)

--- a/app/src/main/java/me/iacn/biliroaming/hook/BangumiPageAdHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/BangumiPageAdHook.kt
@@ -7,18 +7,23 @@ class BangumiPageAdHook(classLoader: ClassLoader) : BaseHook(classLoader) {
     override fun startHook() {
         if (!sPrefs.getBoolean("block_view_page_ads", false)) return
         Log.d("startHook: BangumiPageAd")
-        // activity toast ad
-        "com.bilibili.bangumi.data.page.detail.entity.OGVActivityVo".from(mClassLoader)
-            ?.hookBeforeAllConstructors { param ->
-                val args = param.args
-                for (i in args.indices) {
-                    when (val item = args[i]) {
-                        is Int -> args[i] = 0
-                        is MutableList<*> -> item.clear()
-                        else -> args[i] = null
-                    }
+
+        val oGVActivityVoHooker: Hooker = { param ->
+            val args = param.args
+            for (i in args.indices) {
+                when (val item = args[i]) {
+                    is Int -> args[i] = 0
+                    is MutableList<*> -> item.clear()
+                    else -> args[i] = null
                 }
             }
+        }
+        // activity toast ad
+        "com.bilibili.bangumi.data.page.detail.entity.OGVActivityVo".from(mClassLoader)
+            ?.hookBeforeAllConstructors(oGVActivityVoHooker)
+        "com.bilibili.ship.theseus.ogv.activity.OGVActivityVo".from(mClassLoader)
+            ?.hookBeforeAllConstructors(oGVActivityVoHooker)
+
         // mall
         instance.bangumiUniformSeasonActivityEntrance()?.let {
             instance.bangumiUniformSeasonClass?.replaceMethod(it) { null }

--- a/app/src/main/java/me/iacn/biliroaming/hook/BangumiPlayUrlHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/BangumiPlayUrlHook.kt
@@ -763,6 +763,21 @@ class BangumiPlayUrlHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                 val supportedConf = arcConf { isSupport = true }
                 supportedPlayArcIndices.forEach { arcConf[it] = supportedConf }
             }
+            if (!hasPlayArc()) {
+                playArc = playArc {
+                    val episode = thaiEp.value
+                    aid = episode.optLong("aid")
+                    cid = episode.optLong("cid")
+                    videoType = BizType.BIZ_TYPE_PGC
+                    episode.optJSONObject("dimension")?.run {
+                        dimension = dimension {
+                            width = optLong("width")
+                            height = optLong("height")
+                            rotate = optLong("rotate")
+                        }
+                    }
+                }
+            }
         }.toByteArray()
         response.javaClass.callStaticMethod("parseFrom", newRes)
     }.onFailure { Log.e(it) }.getOrDefault(response)

--- a/app/src/main/java/me/iacn/biliroaming/hook/BangumiPlayUrlHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/BangumiPlayUrlHook.kt
@@ -181,7 +181,7 @@ class BangumiPlayUrlHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                     } catch (e: CustomServerException) {
                         param.result = showPlayerError(
                             response,
-                            "请求解析中服务器发生错误(点此查看更多)\n${e.message}"
+                            "请求解析服务器发生错误(点此查看更多)\n${e.message}"
                         )
                         Log.toast("请求解析服务器发生错误: ${e.message}", alsoLog = true)
                     }
@@ -256,7 +256,7 @@ class BangumiPlayUrlHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                     } catch (e: CustomServerException) {
                         param.result = showPlayerError(
                             response,
-                            "请求解析中服务器发生错误(点此查看更多)\n${e.message}"
+                            "请求解析服务器发生错误(点此查看更多)\n${e.message}"
                         )
                         Log.toast("请求解析服务器发生错误: ${e.message}", alsoLog = true)
                     }
@@ -332,7 +332,7 @@ class BangumiPlayUrlHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                     } catch (e: CustomServerException) {
                         param.result = showPlayerErrorUnite(
                             response, supplement,
-                            "请求解析中服务器发生错误", e.message, true
+                            "请求解析服务器发生错误", e.message, true
                         )
                         Log.toast("请求解析服务器发生错误: ${e.message}", alsoLog = true)
                     }

--- a/app/src/main/java/me/iacn/biliroaming/hook/BangumiPlayUrlHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/BangumiPlayUrlHook.kt
@@ -348,28 +348,28 @@ class BangumiPlayUrlHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                 instance.playViewUniteReqClass,
                 instance.mossResponseHandlerClass
             ) { param ->
-                val request = param.args[0]
-                val vod = request.callMethod("getVod") ?: return@hookBeforeMethod
-                isDownload = sPrefs.getBoolean("allow_download", false)
-                        && vod.callMethodAs<Int>("getDownload") >= 1
-                if (isDownload) {
-                    if (!sPrefs.getBoolean("fix_download", false)
-                        || vod.callMethodAs<Int>("getFnval") <= 1
-                    ) {
-                        vod.callMethod("setFnval", MAX_FNVAL)
-                        vod.callMethod("setFourk", true)
-                    }
-                    vod.callMethod("setDownload", 0)
-                } else if (halfScreenQuality != 0 || fullScreenQuality != 0) {
-                    // unlock available quality limit, allow quality up to 8K
-                    vod.callMethod("setFnval", MAX_FNVAL)
-                    vod.callMethod("setFourk", true)
-                    if (halfScreenQuality != 0 && qnApplied.compareAndSet(false, true)) {
-                        if (halfScreenQuality != 1) {
-                            vod.callMethod("setQn", halfScreenQuality)
-                        } else {
-                            // follow full screen quality
-                            defaultQn?.let { vod.callMethod("setQn", it) }
+                param.args[0].callMethod("getVod")?.apply {
+                    isDownload = sPrefs.getBoolean("allow_download", false)
+                            && callMethodAs<Int>("getDownload") >= 1
+                    if (isDownload) {
+                        if (!sPrefs.getBoolean("fix_download", false)
+                            || callMethodAs<Int>("getFnval") <= 1
+                        ) {
+                            callMethod("setFnval", MAX_FNVAL)
+                            callMethod("setFourk", true)
+                        }
+                        callMethod("setDownload", 0)
+                    } else if (halfScreenQuality != 0 || fullScreenQuality != 0) {
+                        // unlock available quality limit, allow quality up to 8K
+                        callMethod("setFnval", MAX_FNVAL)
+                        callMethod("setFourk", true)
+                        if (halfScreenQuality != 0 && qnApplied.compareAndSet(false, true)) {
+                            if (halfScreenQuality != 1) {
+                                callMethod("setQn", halfScreenQuality)
+                            } else {
+                                // follow full screen quality
+                                defaultQn?.let { callMethod("setQn", it) }
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/me/iacn/biliroaming/hook/BangumiSeasonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/BangumiSeasonHook.kt
@@ -1032,7 +1032,14 @@ class BangumiSeasonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
     }
 
     private fun fixViewProto(resp: Any, supplement: ViewPgcAny): Any? {
-        Log.toast("发现区域限制视频，尝试解锁……")
+        val isAreaLimit = supplement.ogvData.rights.areaLimit != 0
+        val unlockDownload = sPrefs.getBoolean("allow_download", false)
+
+        if (!(isAreaLimit || unlockDownload))
+            return null
+
+        if (isAreaLimit)
+            Log.toast("发现区域限制视频，尝试解锁……")
 
         resp.callMethod("getArc")?.callMethod("getRight")?.run {
             callMethod("setDownload", true)
@@ -1043,12 +1050,14 @@ class BangumiSeasonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
         val newSupplement = supplement.copy {
             ogvData = ogvData.copy {
                 rights = rights.copy {
-                    allowDownload = 1
+                    if (unlockDownload) {
+                        allowDownload = 1
+                        onlyVipDownload = 0
+                        newAllowDownload = 1
+                    }
                     allowReview = 1
                     areaLimit = 0
                     banAreaShow = 1
-                    onlyVipDownload = 0
-                    newAllowDownload = 1
                 }
             }
         }
@@ -1080,7 +1089,9 @@ class BangumiSeasonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                                                 }
                                             }
                                             rights = rights.copy {
-                                                allowDownload = 1
+                                                if (unlockDownload) {
+                                                    allowDownload = 1
+                                                }
                                                 allowReview = 1
                                                 canWatch = 1
                                                 allowDm = 1

--- a/app/src/main/java/me/iacn/biliroaming/hook/BangumiSeasonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/BangumiSeasonHook.kt
@@ -1055,7 +1055,7 @@ class BangumiSeasonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                     }
                     allowReview = 1
                     areaLimit = 0
-                    banAreaShow = 1
+                    banAreaShow = 0
                 }
             }
         }

--- a/app/src/main/java/me/iacn/biliroaming/hook/CopyHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/CopyHook.kt
@@ -83,6 +83,17 @@ class CopyHook(classLoader: ClassLoader) : BaseHook(classLoader) {
         instance.commentCopyNewClass?.replaceMethod("onLongClick", View::class.java) {
             commentCopyHook(it, "comment_message")
         }
+        instance.comment3CopyClass?.let { c ->
+            instance.comment3Copy()?.let { m ->
+                c.replaceAllMethods(m) { param ->
+                    val view = param.args[2] as View
+                    view.getFirstFieldByExactTypeOrNull<CharSequence>()?.also { text ->
+                        showCopyDialog(view.context, text, param)
+                    }
+                    return@replaceAllMethods true
+                }
+            }
+        }
 
         if (!sPrefs.getBoolean("comment_copy_enhance", false)) return
         "com.bilibili.bplus.im.conversation.ConversationActivity".from(mClassLoader)

--- a/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
@@ -42,6 +42,8 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
         val searchRanksClass = "com.bilibili.search.api.SearchRanks".findClassOrNull(mClassLoader)
         val searchReferralClass =
             "com.bilibili.search.api.SearchReferral".findClassOrNull(mClassLoader)
+        val searchReferralV2Class =
+            "com.bilibili.search2.api.SearchReferral".findClassOrNull(mClassLoader)
         val followingcardSearchRanksClass =
             "com.bilibili.bplus.followingcard.net.entity.b".findClassOrNull(mClassLoader)
         val spaceClass =
@@ -250,7 +252,7 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                     result.getObjectFieldOrNullAs<MutableList<*>>("splashList")?.clear()
                     result.getObjectFieldOrNullAs<MutableList<*>>("strategyList")?.clear()
                 }
-                defaultWordClass, defaultKeywordClass, searchRanksClass, searchReferralClass, followingcardSearchRanksClass -> if (sPrefs.getBoolean(
+                defaultWordClass, defaultKeywordClass, searchRanksClass, searchReferralClass, searchReferralV2Class, followingcardSearchRanksClass -> if (sPrefs.getBoolean(
                         "purify_search",
                         false
                     ) &&

--- a/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/JsonHook.kt
@@ -344,6 +344,9 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
         val searchRankClass = "com.bilibili.search.api.SearchRank".findClass(mClassLoader)
         val searchGuessClass =
             "com.bilibili.search.api.SearchReferral\$Guess".findClass(mClassLoader)
+        val searchRankV2Class = "com.bilibili.search2.api.SearchRank".from(mClassLoader) ?: searchRankClass
+        val searchGuessV2Class =
+            "com.bilibili.search2.api.SearchReferral\$Guess".from(mClassLoader) ?: searchGuessClass
         val categoryClass = "tv.danmaku.bili.category.CategoryMeta".findClass(mClassLoader)
 
         instance.fastJsonClass?.hookAfterMethod(
@@ -354,7 +357,7 @@ class JsonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
             @Suppress("UNCHECKED_CAST")
             val result = param.result as? MutableList<Any>
             when (param.args[1] as Class<*>) {
-                searchRankClass, searchGuessClass ->
+                searchRankClass, searchGuessClass, searchRankV2Class, searchGuessV2Class ->
                     if (sPrefs.getBoolean("purify_search", false) && sPrefs.getBoolean(
                             "hidden",
                             false

--- a/app/src/main/java/me/iacn/biliroaming/hook/ProtoBufHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/ProtoBufHook.kt
@@ -4,6 +4,15 @@ import me.iacn.biliroaming.BiliBiliPackage.Companion.instance
 import me.iacn.biliroaming.utils.*
 
 class ProtoBufHook(classLoader: ClassLoader) : BaseHook(classLoader) {
+    companion object {
+        fun Any.removeCmdDms() {
+            callMethod("clearActivityMeta")
+            runCatchingOrNull {
+                callMethod("clearCommand")
+            }
+            setObjectField("unknownFields", instance.unknownFieldSetLiteInstance)
+        }
+    }
 
     private val mainListReplyClass by Weak { "com.bapis.bilibili.main.community.reply.v1.MainListReply" from mClassLoader }
     private val subjectDescriptionReplyClass by Weak { "com.bapis.bilibili.main.community.reply.v2.SubjectDescriptionReply" from mClassLoader }
@@ -105,16 +114,8 @@ class ProtoBufHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                 "tFInfo", "com.bapis.bilibili.app.view.v1.TFInfoReq"
             ) { null }
             instance.dmMossClass?.hookAfterMethod(
-                "dmView", "com.bapis.bilibili.community.service.dm.v1.DmViewReq",
-            ) {
-                it.result?.run {
-                    callMethod("clearActivityMeta")
-                    runCatchingOrNull {
-                        callMethod("clearCommand")
-                    }
-                    setObjectField("unknownFields", instance.unknownFieldSetLiteInstance)
-                }
-            }
+                "dmView", instance.dmViewReqClass,
+            ) { it.result?.removeCmdDms() }
         }
         if (hidden && purifySearch) {
             "com.bapis.bilibili.app.interfaces.v1.SearchMoss".hookAfterMethod(

--- a/app/src/main/java/me/iacn/biliroaming/hook/ProtoBufHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/ProtoBufHook.kt
@@ -208,8 +208,7 @@ class ProtoBufHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                     param.result = null
                     return@hookBeforeMethod
                 }
-                if (!blockCommentGuide)
-                    return@hookBeforeMethod
+                if (!blockCommentGuide) return@hookBeforeMethod
                 param.args[1] = param.args[1].mossResponseHandlerProxy { reply ->
                     reply?.runCatchingOrNull {
                         callMethod("getSubjectControl")?.run {
@@ -219,8 +218,8 @@ class ProtoBufHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                             callMethod("getEmptyPage")?.let { page ->
                                 page.callMethod("clearLeftButton")
                                 page.callMethod("clearRightButton")
-                                page.callMethodAs<List<Any>>("getTextsList")
-                                    .takeIf { it.size > 1 }?.let {
+                                page.callMethodAs<List<Any>>("getTextsList").takeIf { it.size > 1 }
+                                    ?.let {
                                         page.callMethod("clearTexts")
                                         page.callMethod("addTexts", it.first().apply {
                                             callMethod("setRaw", "还没有评论哦")
@@ -237,12 +236,12 @@ class ProtoBufHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                     "com.bapis.bilibili.main.community.reply.v2.SubjectDescriptionReq",
                     instance.mossResponseHandlerClass
                 ) { param ->
-                    val tipStr = if (hidden && blockVideoComment) {
-                        "评论区已由漫游屏蔽"
-                    } else {
-                        "还没有评论哦"
-                    }
                     val defaultText = textV2Class?.new()?.apply {
+                        val tipStr = if (hidden && blockVideoComment) {
+                            "评论区已由漫游屏蔽"
+                        } else {
+                            "还没有评论哦"
+                        }
                         callMethod("setRaw", tipStr)
                         textStyleV2Class?.new()?.apply {
                             callMethod("setFontSize", 14)
@@ -254,23 +253,19 @@ class ProtoBufHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                     } ?: return@hookBeforeMethod
                     param.args[1] = param.args[1].mossResponseHandlerProxy { reply ->
                         reply?.runCatchingOrNull {
-                            callMethod("setCount", 0L)
-                            callMethod("getEmptyPage")?.let { page ->
-                                page.run {
-                                    callMethod("clearLeftButton")
-                                    callMethod("clearRightButton")
-                                    callMethod("ensureTextsIsMutable")
-                                    callMethodAs<MutableList<Any>>("getTextsList").run {
-                                        clear()
-                                        add(defaultText)
-                                    }
-                                    if (hidden && blockVideoComment) {
-                                        callMethod(
-                                            "setImageUrl",
-                                            "https://i0.hdslb.com/bfs/app-res/android/img_holder_forbid_style1.webp"
-                                        )
-                                    }
+                            callMethod("getEmptyPage")?.run {
+                                callMethod("clearLeftButton")
+                                callMethod("clearRightButton")
+                                callMethod("ensureTextsIsMutable")
+                                callMethodAs<MutableList<Any>>("getTextsList").run {
+                                    clear()
+                                    add(defaultText)
                                 }
+                                if (!(hidden && blockVideoComment)) return@run
+                                callMethod(
+                                    "setImageUrl",
+                                    "https://i0.hdslb.com/bfs/app-res/android/img_holder_forbid_style1.webp"
+                                )
                             }
                         }
                     }
@@ -280,6 +275,7 @@ class ProtoBufHook(classLoader: ClassLoader) : BaseHook(classLoader) {
         if (!(hidden && (blockViewPageAds || removeHonor))) return
         // 视频详情页荣誉卡片
         fun Any.isHonor() = callMethodAs("hasHonor") && removeHonor
+
         // 视频详情页活动卡片(含会员购等), 区分于视频下方推荐处的广告卡片
         fun Any.isActivityEntranceModule() =
             callMethodAs("hasActivityEntranceModule") && blockViewPageAds
@@ -289,8 +285,7 @@ class ProtoBufHook(classLoader: ClassLoader) : BaseHook(classLoader) {
         }
 
         instance.viewUniteMossClass?.hookAfterMethod(
-            "view",
-            instance.viewUniteReqClass
+            "view", instance.viewUniteReqClass
         ) { param ->
             if (instance.networkExceptionClass?.isInstance(param.throwable) == true) return@hookAfterMethod
             param.result ?: return@hookAfterMethod
@@ -302,11 +297,10 @@ class ProtoBufHook(classLoader: ClassLoader) : BaseHook(classLoader) {
             param.result.callMethod("getTab")?.run {
                 callMethod("ensureTabModuleIsMutable")
                 callMethodAs<MutableList<Any>>("getTabModuleList").map {
-                    if (it.callMethodAs("hasIntroduction")) {
-                        it.callMethodAs<Any>("getIntroduction").run {
-                            callMethod("ensureModulesIsMutable")
-                            callMethodAs<MutableList<Any>>("getModulesList").filter()
-                        }
+                    if (!it.callMethodAs<Boolean>("hasIntroduction")) return@map
+                    it.callMethodAs<Any>("getIntroduction").run {
+                        callMethod("ensureModulesIsMutable")
+                        callMethodAs<MutableList<Any>>("getModulesList").filter()
                     }
                 }
             }

--- a/app/src/main/java/me/iacn/biliroaming/hook/ProtoBufHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/ProtoBufHook.kt
@@ -15,11 +15,9 @@ class ProtoBufHook(classLoader: ClassLoader) : BaseHook(classLoader) {
     }
 
     private val mainListReplyClass by Weak { "com.bapis.bilibili.main.community.reply.v1.MainListReply" from mClassLoader }
-    private val subjectDescriptionReplyClass by Weak { "com.bapis.bilibili.main.community.reply.v2.SubjectDescriptionReply" from mClassLoader }
     private val emptyPageV1Class by Weak { "com.bapis.bilibili.main.community.reply.v1.EmptyPage" from mClassLoader }
     private val textV1Class by Weak { "com.bapis.bilibili.main.community.reply.v1.EmptyPage\$Text" from mClassLoader }
     private val textStyleV1Class by Weak { "com.bapis.bilibili.main.community.reply.v1.TextStyle" from mClassLoader }
-    private val emptyPageV2Class by Weak { "com.bapis.bilibili.main.community.reply.v2.EmptyPage" from mClassLoader }
     private val textV2Class by Weak { "com.bapis.bilibili.main.community.reply.v2.EmptyPage\$Text" from mClassLoader }
     private val textStyleV2Class by Weak { "com.bapis.bilibili.main.community.reply.v2.TextStyle" from mClassLoader }
     private val videoGuideClass by Weak { "com.bapis.bilibili.app.view.v1.VideoGuide" from mClassLoader }

--- a/app/src/main/java/me/iacn/biliroaming/hook/ProtoBufHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/ProtoBufHook.kt
@@ -87,7 +87,7 @@ class ProtoBufHook(classLoader: ClassLoader) : BaseHook(classLoader) {
             ) { param ->
                 param.result?.callMethod("setVideoGuide", videoGuideClass?.new())
             }
-            "com.bapis.bilibili.app.viewunite.v1.ViewMoss".from(mClassLoader)?.hookAfterMethod(
+            instance.viewUniteMossClass?.hookAfterMethod(
                 "viewProgress",
                 "com.bapis.bilibili.app.viewunite.v1.ViewProgressReq"
             ) { param ->

--- a/app/src/main/java/me/iacn/biliroaming/hook/ProtoBufHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/ProtoBufHook.kt
@@ -280,8 +280,11 @@ class ProtoBufHook(classLoader: ClassLoader) : BaseHook(classLoader) {
         fun Any.isActivityEntranceModule() =
             callMethodAs("hasActivityEntranceModule") && blockViewPageAds
 
+        // 视频详情页直播预约卡片
+        fun Any.isLiveOrder() = callMethodAs("hasLiveOrder") && blockLiveOrder
+
         fun MutableList<Any>.filter() = removeAll {
-            it.isActivityEntranceModule() || it.isHonor()
+            it.isActivityEntranceModule() || it.isHonor() || it.isLiveOrder()
         }
 
         instance.viewUniteMossClass?.hookAfterMethod(

--- a/app/src/main/java/me/iacn/biliroaming/hook/ProtoBufHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/ProtoBufHook.kt
@@ -272,7 +272,7 @@ class ProtoBufHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                 }
         }
 
-        if (!(hidden && (blockViewPageAds || removeHonor))) return
+        if (!(hidden && (blockViewPageAds || removeHonor || blockVideoComment))) return
         // 视频详情页荣誉卡片
         fun Any.isHonor() = callMethodAs("hasHonor") && removeHonor
 
@@ -296,7 +296,12 @@ class ProtoBufHook(classLoader: ClassLoader) : BaseHook(classLoader) {
 
             param.result.callMethod("getTab")?.run {
                 callMethod("ensureTabModuleIsMutable")
-                callMethodAs<MutableList<Any>>("getTabModuleList").map {
+                val tabModuleList = callMethodAs<MutableList<Any>>("getTabModuleList")
+                tabModuleList.removeAll {
+                    blockVideoComment && it.callMethodAs("hasReply")
+                }
+                if (!(blockViewPageAds || removeHonor)) return@run
+                tabModuleList.map {
                     if (!it.callMethodAs<Boolean>("hasIntroduction")) return@map
                     it.callMethodAs<Any>("getIntroduction").run {
                         callMethod("ensureModulesIsMutable")

--- a/app/src/main/java/me/iacn/biliroaming/hook/SubtitleHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/SubtitleHook.kt
@@ -319,6 +319,11 @@ class SubtitleHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                     if (subtitles.length() != 0) {
                         extraSubtitles += subtitles.toSubtitles()
                     }
+                    // Disable danmaku for Area Th
+                    param.result.apply {
+                        callMethod("setClosed", true)
+                        callMethod("setInputPlaceholder", "漫游泰区不支持弹幕")
+                    }
                 }
             }
 

--- a/app/src/main/java/me/iacn/biliroaming/utils/Utils.kt
+++ b/app/src/main/java/me/iacn/biliroaming/utils/Utils.kt
@@ -387,6 +387,24 @@ inline fun Any.mossResponseHandlerProxy(crossinline onNext: (reply: Any?) -> Uni
     }
 }
 
+inline fun Any.mossResponseHandlerReplaceProxy(crossinline onNext: (reply: Any?) -> Any?): Any {
+    return Proxy.newProxyInstance(
+        javaClass.classLoader,
+        arrayOf(instance.mossResponseHandlerClass)
+    ) { _, m, args ->
+        if (m.name == "onNext") {
+            onNext(args[0])?.let {
+                args[0] = it
+            }
+            m(this, *args)
+        } else if (args == null) {
+            m(this)
+        } else {
+            m(this, *args)
+        }
+    }
+}
+
 @SuppressLint("ApplySharedPref")
 fun SharedPreferences.appendStringForSet(key: String, value: String, commit: Boolean = false) {
     getStringSet(key, null).orEmpty().let {

--- a/app/src/main/java/me/iacn/biliroaming/utils/Utils.kt
+++ b/app/src/main/java/me/iacn/biliroaming/utils/Utils.kt
@@ -388,6 +388,7 @@ inline fun Any.mossResponseHandlerProxy(crossinline onNext: (reply: Any?) -> Uni
 }
 
 inline fun Any.mossResponseHandlerReplaceProxy(crossinline onNext: (reply: Any?) -> Any?): Any {
+    val originalHandler = this
     return Proxy.newProxyInstance(
         javaClass.classLoader,
         arrayOf(instance.mossResponseHandlerClass)
@@ -397,6 +398,13 @@ inline fun Any.mossResponseHandlerReplaceProxy(crossinline onNext: (reply: Any?)
                 args[0] = it
             }
             m(this, *args)
+        } else if (m.name == "onError") {
+            val newResponse = onNext(null)
+            if (newResponse == null) {
+                m(this, *args)
+            } else {
+                originalHandler.callMethod("onNext", newResponse)
+            }
         } else if (args == null) {
             m(this)
         } else {

--- a/app/src/main/proto/me/iacn/biliroaming/api.proto
+++ b/app/src/main/proto/me/iacn/biliroaming/api.proto
@@ -331,6 +331,30 @@ message PlayDeviceConf {}
 message PlayArc {}
 message QnTrialInfo {}
 
+// renamed due to name collision
+message PlaysharedViewInfo {
+  map<string, PlaysharedDialog> dialog_map = 0x1;
+}
+message PlaysharedDialog {
+    int32 style_type = 0x1;
+    BackgroundInfo background_info = 0x2;
+    TextInfo title = 0x3;
+    TextInfo subtitle = 0x4;
+    ImageInfo image = 0x5;
+    repeated ButtonInfo button = 0x6;
+    ButtonInfo bottom_desc = 0x7;
+    int32 count_down_sec = 0x9;
+    TextInfo right_bottom_desc= 0xa;
+    repeated BottomDisplay bottom_display= 0xb;
+    ExtData ext_data= 0xc;
+    int32 limit_action_type= 0xd;
+}
+message BackgroundInfo {
+  optional string drawable_color = 0x1;
+  optional string drawable_bitmap_url = 0x2;
+  optional int32 effects = 0x3;
+}
+message ExtData {}
 message PlayViewUniteReply {
   optional VideoInfo vod_info = 0x1;
   optional PlayArcConf play_arc_conf = 0x2;
@@ -340,6 +364,7 @@ message PlayViewUniteReply {
   optional PlayArc play_arc = 0x6;
   optional QnTrialInfo qn_trial_info = 0x7;
   optional History history = 0x8;
+  optional PlaysharedViewInfo view_info = 0x9;
 }
 
 message VideoVod {
@@ -377,6 +402,22 @@ message ViewReq {
   optional string from_spmid = 0xc;
   optional int32 autoplay = 0xd;
   optional PlayerArgs player_args = 0xe;
+}
+
+message ViewUniteReq {
+  optional uint64 aid = 0x1;
+  optional string bvid = 0x2;
+  optional string from = 0x3;
+  optional string spmid = 0x4;
+  optional string from_spmid = 0x5;
+  optional string session_id = 0x6;
+  optional PlayerArgs player_args = 0x7;
+  optional string track_id = 0x8;
+  map<string, string> extra_content = 0x9;
+  optional string play_mode = 0xa;
+  optional Relate relate = 0xb;
+  optional string biz_extra = 0xc;
+  optional string ad_extra = 0xd;
 }
 
 message UserSeason {optional string attention = 0x1;}
@@ -648,6 +689,432 @@ message ViewReply {
   optional UgcSeason ugc_season = 0x18;
   optional string vip_active = 0xd;
 }
+
+message ViewUniteReply {
+  optional ViewBase view_base = 0x1;
+  optional ViewUniteArc arc = 0x2;
+  // optional Owner owner = 0x4;
+  optional Tab tab = 0x5;
+  optional google.protobuf.Any supplement = 0x6;
+}
+message ViewBase {
+  enum PageType {
+    H5 = 0x0;
+    NA = 0x1;
+  }
+  optional int32 biz_type = 0x1;
+  optional PageType page_type = 0x2;
+}
+// Renamed due to name collision
+message ViewUniteArc {
+  optional int64 aid = 0x1;
+  optional int64 cid = 0x2;
+  optional int64 duration = 0x3;
+  optional string bvid = 0x5;
+  optional int32 copyright = 0x6;
+  optional ViewUniteArcRights right = 0x7;
+  optional string cover = 0x8;
+  optional int64 type_id = 0x9;
+  optional string title= 0xa;
+}
+// Renamed due to name collision
+message ViewUniteArcRights {
+  optional bool only_vip_download = 0x1;
+  optional bool no_reprint = 0x2;
+  optional bool download = 0x3;
+}
+message ViewPgcAny {
+  optional OgvData ogv_data = 0x1;
+}
+message OgvData {
+  optional int32 media_id = 0x1;
+  optional int64 season_id = 0x2;
+  optional int32 season_type = 0x3;
+  optional int32 show_season_type = 0x4;
+  optional OgvDataRights rights = 0x5;
+  optional OgvDataUserStatus user_status = 0x6;
+  optional int64 aid = 0x7;
+  optional OgvDataStat stat = 0x8;
+  optional int32 mode = 0x9;
+  optional Publish publish = 0xa;
+  optional PlayStrategy play_strategy = 0xb;
+  optional MultiViewInfo multi_view_info = 0xc;
+  optional OgvSwitch ogv_switch = 0xd;
+  optional int32 total_ep = 0xe;
+  optional NewEp new_ep = 0xf;
+  optional Reserve reserve = 0x10;
+  optional int32 status = 0x11;
+  repeated PlayFloatLayerActivity activity_float_layer = 0x12;
+  optional EarphoneConf earphone_conf = 0x13;
+  optional string cover = 0x14;
+  optional string square_cover = 0x15;
+  optional string share_url = 0x16;
+  optional string short_link = 0x17;
+  optional string title = 0x18;
+  optional string horizontal_cover169 = 0x19;
+  optional string horizontal_cover1610 = 0x1a;
+  optional int32 has_can_play_ep = 0x1b;
+}
+message OgvDataRights {
+  optional int32 allow_download = 0x1;
+  optional int32 allow_review = 0x2;
+  optional int32 can_watch = 0x3;
+  optional int32 is_cover_show = 0x4;
+  optional string copyright = 0x5;
+  optional string copyright_name = 0x6;
+  optional int32 allow_bp = 0x7;
+  optional int32 area_limit = 0x8;
+  optional int32 is_preview = 0x9;
+  optional int32 ban_area_show = 0xa;
+  optional int32 watch_platform = 0xb;
+  optional int32 allow_bp_rank = 0xc;
+  optional string resource = 0xd;
+  optional int32 forbid_pre = 0xe;
+  optional int32 only_vip_download = 0xf;
+  optional int32 new_allow_download = 0x10;
+}
+message OgvDataUserStatus {
+  optional int32 show = 0x1;
+  optional int32 follow = 0x2;
+  optional int32 follow_status = 0x3;
+  optional int32 pay = 0x4;
+  optional int32 sponsor = 0x5;
+  optional int32 vip = 0x6;
+  optional int32 vip_frozen = 0x7;
+}
+message OgvDataStat {
+  optional string followers = 0x1;
+  optional StatInfo play_data = 0x2;
+}
+message StatInfo {
+  optional int64 value = 0x1;
+  optional string text = 0x2;
+  optional string pure_text = 0x3;
+  optional string icon = 0x4;
+}
+message Publish {
+  optional string pub_time = 0x1;
+  optional string pub_time_show = 0x2;
+  optional int32 is_started = 0x3;
+  optional int32 is_finish = 0x4;
+  optional int32 weekday = 0x5;
+  optional string release_date_show = 0x6;
+  optional string time_length_show = 0x7;
+  optional int32 unknow_pub_date = 0x8;
+  optional string update_info_desc = 0x9;
+}
+message NewEp {
+  optional int32 id = 0x1;
+  optional string title = 0x2;
+  optional string desc = 0x3;
+  optional int32 is_new = 0x4;
+  optional string more = 0x5;
+  optional string cover = 0x6;
+  optional string index_show = 0x7;
+}
+message PlayStrategy {
+  repeated string strategies = 0x1;
+  optional int32 recommend_show_strategy = 0x2;
+  optional string auto_play_toast = 0x3;
+}
+message MultiViewInfo {}
+message OgvSwitch {
+  optional int32 reduce_short_title_spacing = 0x1;
+  optional int32 merge_position_section_for_cinema = 0x2;
+  optional int32 merge_preview_section = 0x3;
+  optional int32 enable_show_vt_info = 0x4;
+}
+message Reserve {}
+message PlayFloatLayerActivity {}
+message EarphoneConf {}
+
+message Tab {
+  repeated TabModule tab_module = 0x1;
+}
+message TabModule {
+  optional TabType tab_type = 0x1;
+  oneof tab {
+    IntroductionTab introduction = 0x2;
+    ReplyTab reply = 0x3;
+    ActivityTab activity_tab = 0x4;
+  }
+}
+enum TabType {
+  TAB_NONE = 0x0;
+  TAB_INTRODUCTION = 0x1;
+  TAB_REPLY = 0x2;
+  TAB_OGV_ACTIVITY = 0x3;
+}
+message IntroductionTab {
+  string title = 0x1;
+  repeated Module modules = 0x2;
+}
+message Module {
+  ModuleType type = 0x1;
+  oneof data {
+      OgvIntroduction ogv_introduction = 0x2;
+      UgcIntroduction ugc_introduction = 0x3;
+      KingPosition king_position = 0x4;
+      Headline head_line = 0x5;
+      OgvTitle ogv_title = 0x6;
+      Honor honor = 0x7;
+      UserList list = 0x8;
+      Staffs staffs = 0x9;
+      ActivityReserve activity_reserve= 0xa;
+      LiveOrder live_order= 0xb;
+      SectionData section_data= 0xc;
+      DeliveryData delivery_data= 0xd;
+      FollowLayer follow_layer= 0xe;
+      OgvSeasons ogv_seasons= 0xf;
+      UgcSeasons ugc_season = 0x10;
+      OgvLiveReserve ogv_live_reserve = 0x11;
+      CombinationEp combination_ep = 0x12;
+      Sponsor sponsor = 0x13;
+      ActivityEntranceModule activity_entrance_module = 0x14;
+      SerialSeason serial_season = 0x15;
+      Relates relates = 0x16;
+      Banner banner = 0x17;
+      Audio audio = 0x18;
+      LikeComment like_comment = 0x19;
+      AttentionRecommend attention_recommend = 0x1a;
+      Covenanter covenanter = 0x1b;
+  }
+}
+enum ModuleType {
+  UNKNOWN = 0x0;
+  OGV_INTRODUCTION = 0x1;
+  OGV_TITLE = 0x2;
+  UGC_HEADLINE = 0x3;
+  UGC_INTRODUCTION = 0x4;
+  KING_POSITION = 0x5;
+  MASTER_USER_LIST = 0x6;
+  STAFFS = 0x7;
+  HONOR = 0x8;
+  OWNER = 0x9;
+  PAGE= 0xa;
+  ACTIVITY_RESERVE= 0xb;
+  LIVE_ORDER= 0xc;
+  POSITIVE= 0xd;
+  SECTION= 0xe;
+  RELATE= 0xf;
+  PUGV = 0x10;
+  COLLECTION_CARD = 0x11;
+  ACTIVITY = 0x12;
+  CHARACTER = 0x13;
+  FOLLOW_LAYER = 0x14;
+  OGV_SEASONS = 0x15;
+  UGC_SEASON = 0x16;
+  OGV_LIVE_RESERVE = 0x17;
+  COMBINATION_EPISODE = 0x18;
+  SPONSOR = 0x19;
+  ACTIVITY_ENTRANCE = 0x1a;
+  THEATRE_HOT_TOPIC = 0x1b;
+  RELATED_RECOMMEND = 0x1c;
+  PAY_BAR = 0x1d;
+  BANNER = 0x1e;
+  AUDIO = 0x1f;
+  AGG_CARD = 0x20;
+  SINGLE_EP = 0x21;
+  LIKE_COMMENT = 0x22;
+  ATTENTION_RECOMMEND = 0x23;
+  COVENANTER = 0x24;
+}
+message OgvIntroduction {
+  optional string followers = 0x1;
+  optional string score = 0x2;
+  optional StatInfo play_data = 0x3;
+}
+message UgcIntroduction {}
+message KingPosition {
+  repeated KingPos king_pos = 0x1;
+  repeated KingPos extenf = 0x2;
+}
+message KingPos {
+  enum KingPositionType {
+    KING_POS_UNSPECIFIED = 0x0;
+    LIKE = 0x1;
+    DISLIKE = 0x2;
+    COIN = 0x3;
+    FAV = 0x4;
+    SHARE = 0x5;
+    CACHE = 0x6;
+    DANMAKU = 0x7;
+  }
+  message LikeExtend {}
+  message CoinExtend {}
+  optional bool disable = 0x1;
+  optional string icon = 0x2;
+  optional KingPositionType type = 0x3;
+  optional string disable_toast = 0x4;
+  optional string checked_post = 0x5;
+  oneof extend {
+    LikeExtend like = 0x6;
+    CoinExtend coin = 0x7;
+  }
+}
+message Headline {}
+message OgvTitle {
+  optional string title = 0x1;
+  optional BadgeInfo badge_info = 0x2;
+  optional int32 is_show_btn_animation = 0x3;
+  optional int32 follow_video_is_reserve_live = 0x4;
+  optional int64 reserve_id = 0x5;
+}
+message BadgeInfo {
+  optional string text = 0x1;
+  optional string text_color = 0x2;
+  optional string text_color_night = 0x3;
+  optional string bg_color = 0x4;
+  optional string bg_color_night = 0x5;
+  optional string border_color = 0x6;
+  optional string border_color_night = 0x7;
+  optional int32 bg_style = 0x8;
+  optional string img = 0x9;
+  optional int32 type= 0xa;
+}
+message UserList {}
+message Staffs {}
+message ActivityReserve {}
+message LiveOrder {}
+message SectionData {
+  optional int32 id = 0x1;
+  optional int32 section_id = 0x2;
+  optional string title = 0x3;
+  optional int32 can_ord_desc = 0x4;
+  optional string more = 0x5;
+  repeated int32 episode_ids = 0x6;
+  repeated ViewEpisode episodes = 0x7;
+  optional string split_text = 0x8;
+  optional Style module_style = 0x9;
+  optional string more_bottom_desc= 0xa;
+  repeated SerialSeason seasons= 0xb;
+  optional SectionDataButton more_left= 0xc;
+  optional int32 type= 0xd;
+}
+message ViewEpisode {
+  optional int64 ep_id = 0x1;
+  optional string badge = 0x2;
+  optional int32 badge_type = 0x3;
+  optional BadgeInfo badge_info = 0x4;
+  optional int32 duration = 0x5;
+  optional int32 status = 0x6;
+  optional string cover = 0x7;
+  optional int64 aid = 0x8;
+  optional string title = 0x9;
+  optional string movie_title= 0xa;
+  optional string subtitle= 0xb;
+  optional string long_title= 0xc;
+  optional string toast_title= 0xd;
+  optional int64 cid= 0xe;
+  optional string from= 0xf;
+  optional string share_url = 0x10;
+  optional string share_copy = 0x11;
+  optional string short_link = 0x12;
+  optional string vid = 0x13;
+  optional string release_date = 0x14;
+  optional Dimension dimension = 0x15;
+  optional ViewEpisodeRights rights = 0x16;
+  optional Interaction interaction = 0x17;
+  optional string bvid = 0x18;
+  optional int32 archive_attr = 0x19;
+  optional string link = 0x1a;
+  optional string link_type = 0x1b;
+  optional string bmid = 0x1c;
+  optional int64 pub_time = 0x1d;
+  optional int32 pv = 0x1e;
+  optional int32 ep_index = 0x1f;
+  optional int32 section_index = 0x20;
+  repeated Staff up_infos = 0x21;
+  optional Staff up_info = 0x22;
+  optional string dialog_type = 0x23;
+  optional string toast_type = 0x24;
+  optional bool is_sub_view = 38;
+  optional bool is_view_hide = 39;
+  optional string jump_link = 40;
+  optional ViewEpisodeStat stat_for_unity = 41;
+}
+message ViewEpisodeRights {
+  optional int32 allow_download = 0x1;
+  optional int32 allow_review = 0x2;
+  optional int32 can_watch = 0x3;
+  optional string resource = 0x4;
+  optional int32 allow_dm = 0x5;
+  optional int32 allow_demand = 0x6;
+  optional int32 area_limit = 0x7;
+}
+message ViewEpisodeStat {
+  StatInfo vt = 0x1;
+  StatInfo danmaku = 0x2;
+  int64 reply = 0x3;
+  int64 fav = 0x4;
+  int64 coin = 0x5;
+  int64 share = 0x6;
+  int64 like = 0x7;
+  int64 follow = 0x8;
+}
+message Style {
+  optional int32 line = 0x1;
+  optional int32 hidden = 0x2;
+  repeated string show_pages = 0x3;
+}
+message SerialSeason {
+  optional int32 season_id = 0x1;
+  optional string title = 0x2;
+  optional string season_title = 0x3;
+  optional int32 is_new = 0x4;
+  optional string cover = 0x5;
+  optional string badge = 0x6;
+  optional int32 badge_type = 0x7;
+  optional BadgeInfo badge_info = 0x8;
+  optional string link = 0x9;
+  optional string resource= 0xa;
+  optional NewEp new_ep= 0xb;
+}
+message SectionDataButton {
+  optional string title = 0x1;
+  optional string left_strikethrough_text = 0x2;
+  optional string type = 0x3;
+  optional string link = 0x4;
+  optional BadgeInfo badge_info = 0x5;
+  optional string sub_title = 0x6;
+}
+message DeliveryData {}
+message FollowLayer {}
+message OgvSeasons {
+  enum SerialSeasonCoverStyle {
+    TITLE = 0x0;
+    PICTURE = 0x1;
+  }
+  optional string title = 0x1;
+  repeated SerialSeason serial_season = 0x2;
+  optional SerialSeasonCoverStyle style = 0x3; 
+}
+message UgcSeasons {}
+message OgvLiveReserve {}
+message CombinationEp {}
+message Sponsor {}
+message ActivityEntranceModule {}
+message Relates {}
+message Banner {}
+message LikeComment {}
+message AttentionRecommend {}
+message Covenanter {}
+message ReplyTab {
+  optional ReplyStyle reply_style = 0x1;
+  optional string title = 0x2;
+  optional TabControl control = 0x3;
+}
+message ReplyStyle {
+  optional string badge_url = 0x1;
+  optional string badge_text = 0x2;
+  optional int64 badge_type = 0x3;
+}
+message TabControl {
+  optional bool limit = 0x1;
+  optional bool disable = 0x2;
+  optional string disable_click_tip = 0x3;
+}
+message ActivityTab {}
 
 message Device {
   optional int32 app_id = 0x1;

--- a/app/src/main/proto/me/iacn/biliroaming/api.proto
+++ b/app/src/main/proto/me/iacn/biliroaming/api.proto
@@ -328,7 +328,33 @@ message PlayArcConf {
 }
 
 message PlayDeviceConf {}
-message PlayArc {}
+message PlayArc {
+  optional BizType video_type = 0x1;
+  optional uint64 aid = 0x2;
+  optional uint64 cid = 0x3;
+  optional DrmTechType drm_tech_type = 0x4;
+  optional ArcType arc_type = 0x5;
+  optional Interaction interaction = 0x6;
+  optional Dimension dimension = 0x7;
+  optional int64 duration = 0x8;
+  optional bool is_preview = 0x9;
+}
+enum BizType {
+  BIZ_TYPE_UNKNOWN = 0x0;
+  BIZ_TYPE_UGC = 0x1;
+  BIZ_TYPE_PGC = 0x2;
+  BIZ_TYPE_PUGV = 0x3;
+}
+enum DrmTechType {
+  UNKNOWN_DRM = 0x0;
+  FAIR_PLAY = 0x1;
+  WIDE_VINE = 0x2;
+  BILI_DRM = 0x3;
+}
+enum ArcType {
+  ARC_TYPE_NORMAL = 0x0;
+  ARC_TYPE_INTERACT = 0x1;
+}
 message QnTrialInfo {}
 
 // renamed due to name collision

--- a/app/src/main/proto/me/iacn/biliroaming/configs.proto
+++ b/app/src/main/proto/me/iacn/biliroaming/configs.proto
@@ -265,6 +265,11 @@ message CardClickProcessor {
   optional Method on_feed_clicked = 2;
 }
 
+message Comment3Copy {
+  optional Class class = 1;
+  optional Method method = 2;
+}
+
 message HookInfo {
   int64 last_update_time = 1;
   optional MapIds map_ids = 2;
@@ -326,4 +331,5 @@ message HookInfo {
   optional BiliGlobalPreference bili_global_preference = 88;
   optional CardClickProcessor card_click_processor = 89;
   optional Class publish_to_following_config = 90;
+  optional Comment3Copy comment3_copy = 91;
 }

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -202,8 +202,8 @@
     <string name="dialog_blur_background_title">全域 Dialog 背景模糊</string>
     <string name="block_up_rcmd_ads_title">封鎖UP主推薦廣告</string>
     <string name="block_up_rcmd_ads_summary">封鎖影片播放過程中，浮窗出現的UP主推薦廣告</string>
-    <string name="block_bangumi_page_ads_title">封鎖番劇頁面廣告</string>
-    <string name="block_bangumi_page_ads_summary">封鎖番劇頁面彈窗廣告及會員購</string>
+    <string name="block_view_page_ads_title">封鎖影片詳情頁面廣告</string>
+    <string name="block_view_page_ads_summary">封鎖影片（包含番劇、普通影片等）詳情頁面的廣告，包括但不限於彈窗廣告、會員購等活動廣告（舊版本僅對番劇頁面生效）。</string>
     <string name="block_live_order_title">封鎖直播預約</string>
     <string name="block_live_order_summary">封鎖影片詳情頁的直播預約信息</string>
     <string name="remove_up_vip_label_title">移除 UP 大會員標識</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -202,8 +202,8 @@
     <string name="dialog_blur_background_title">全局 Dialog 背景模糊</string>
     <string name="block_up_rcmd_ads_title">屏蔽UP主推荐广告</string>
     <string name="block_up_rcmd_ads_summary">屏蔽视频播放过程中，浮窗出现的UP主推荐广告</string>
-    <string name="block_bangumi_page_ads_title">屏蔽番剧页面广告</string>
-    <string name="block_bangumi_page_ads_summary">屏蔽番剧页面弹窗广告及会员购</string>
+    <string name="block_view_page_ads_title">屏蔽视频详情页面广告</string>
+    <string name="block_view_page_ads_summary">屏蔽视频（含番剧，普通视频等）详情页面的广告，包括但不限于弹窗广告，会员购等活动广告（旧版本仅对番剧详情页面生效）。</string>
     <string name="block_live_order_title">屏蔽直播预约</string>
     <string name="block_live_order_summary">屏蔽视频详情页面的直播预约信息</string>
     <string name="remove_up_vip_label_title">移除 UP 大会员标识</string>

--- a/app/src/main/res/xml/prefs_setting.xml
+++ b/app/src/main/res/xml/prefs_setting.xml
@@ -445,9 +445,9 @@
 
         <SwitchPreference
             android:dependency="hidden"
-            android:key="block_bangumi_page_ads"
-            android:summary="@string/block_bangumi_page_ads_summary"
-            android:title="@string/block_bangumi_page_ads_title" />
+            android:key="block_view_page_ads"
+            android:summary="@string/block_view_page_ads_summary"
+            android:title="@string/block_view_page_ads_title" />
 
         <SwitchPreference
             android:dependency="hidden"


### PR DESCRIPTION
fix: 哔哩哔哩粉版 7.41.0+ 由于 API 变动等因素产生的大量问题 #1199
- [x] 简介自由复制失效
- [x] 评论自由复制失效
- [x] ~~屏蔽视频评论区失效(表现为无限加载)~~ 修复后表现为完全移除评论区(入口都没了)
- [x] 屏蔽视频评论区引导失效
- [x] 视频下方推荐广告屏蔽失效
- [x] 移除视频下方荣誉失效
- [x] 番剧页面广告屏蔽失效
- [x] **番剧解锁失效**
- [x] **版权番剧下载失效**
- [x] **东南亚区域番剧插入主站失效** (部分修复)
- [x] 移除视频详情页的直播预约失效
- [x] 移除番剧页面弹窗广告失效(Original PR: #1009)
- [x] 热搜屏蔽失效  #1204  
- [x] **开启其他地区番剧/影剧搜索失效** (starting from 7.39.0)
- [x] 移除视频浮窗部分失效 (starting from 7.42.0?) (Fix #1109)
- [x] 东南亚区域番剧字幕相关功能失效?(starting from 7.41.0?)

仅在粉版测试, HD 版, Play 版未测试, 有问题另外修复.
