### PR TITLE
fix: default playback speed on 7.41.0+

### DIFF
--- a/app/src/main/java/me/iacn/biliroaming/BiliBiliPackage.kt
+++ b/app/src/main/java/me/iacn/biliroaming/BiliBiliPackage.kt
@@ -244,9 +244,13 @@ class BiliBiliPackage constructor(private val mClassLoader: ClassLoader, mContex
 
     fun gson() = mHookInfo.gsonHelper.gson.orNull
 
-    fun defaultSpeed() = mHookInfo.playerCoreService.getDefaultSpeed.orNull
+    fun getPlaybackSpeed() = mHookInfo.playerCoreService.getPlaybackSpeed.orNull
 
-    fun setDefaultSpeed() = mHookInfo.playerCoreService.setDefaultSpeed.orNull
+    fun setPlaybackSpeed() = mHookInfo.playerCoreService.setPlaybackSpeed.orNull
+
+    fun theseusPlayerSetSpeed() = mHookInfo.playerCoreService.theseusPlayerSetSpeed.orNull
+
+    fun playerOnPrepare() = mHookInfo.playerCoreService.playerOnPrepare.orNull
 
     fun urlField() = mHookInfo.okHttp.request.url.orNull
 
@@ -1409,7 +1413,7 @@ class BiliBiliPackage constructor(private val mClassLoader: ClassLoader, mContex
                 onSeekComplete = method { name = onSeekCompleteMethod.name }
                 seekCompleteListener =
                     class_ { name = onSeekCompleteMethod.declaringClass.name }
-                getDefaultSpeed = method {
+                getPlaybackSpeed = method {
                     name = dexHelper.findMethodUsingString(
                         "player_key_video_speed",
                         true,
@@ -1425,13 +1429,49 @@ class BiliBiliPackage constructor(private val mClassLoader: ClassLoader, mContex
                         dexHelper.decodeMethodIndex(it)
                     }?.name ?: return@method
                 }
-                setDefaultSpeed = method {
+                dexHelper.findMethodUsingString(
+                    "player_key_video_speed",
+                    true,
+                    -1,
+                    1,
+                    "VF",
+                    dexHelper.encodeClassIndex(playerCoreServiceClass),
+                    null,
+                    null,
+                    null,
+                    true
+                ).asSequence().firstOrNull()?.also { mIndex ->
+                    dexHelper.decodeMethodIndex(mIndex)?.let {
+                        setPlaybackSpeed = method {
+                            name = it.name
+                        }
+                    }
+                }?.let {
+                    dexHelper.findMethodInvoked(
+                        it,
+                        -1,
+                        -1,
+                        "VF",
+                        -1,
+                        null,
+                        null,
+                        null,
+                        true
+                    ).asSequence().firstNotNullOfOrNull {
+                        dexHelper.decodeMethodIndex(it)
+                    }?.let {
+                        theseusPlayerSetSpeed = method {
+                            name = it.name
+                        }
+                    }
+                }
+                playerOnPrepare = method {
                     name = dexHelper.findMethodUsingString(
-                        "player_key_video_speed",
+                        "[ijk][callback]player onPrepared",
                         true,
                         -1,
-                        1,
-                        "VF",
+                        -1,
+                        "VLL",
                         dexHelper.encodeClassIndex(playerCoreServiceClass),
                         null,
                         null,

--- a/app/src/main/java/me/iacn/biliroaming/hook/MusicNotificationHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/MusicNotificationHook.kt
@@ -209,9 +209,9 @@ class MusicNotificationHook(classLoader: ClassLoader) : BaseHook(classLoader) {
             getCorePlayer(param.thisObject)?.run {
                 position = callMethodAs<Int>(getCurrentPositionMethod).toLong()
                 speed = try {
-                    callMethodAs(instance.defaultSpeed(), true)
+                    callMethodAs(instance.getPlaybackSpeed(), true)
                 } catch (e: Throwable) {
-                    callMethodAs(instance.defaultSpeed())
+                    callMethodAs(instance.getPlaybackSpeed())
                 }
             }
         }

--- a/app/src/main/proto/me/iacn/biliroaming/configs.proto
+++ b/app/src/main/proto/me/iacn/biliroaming/configs.proto
@@ -86,11 +86,13 @@ message GsonHelper {
 
 message PlayerCoreService {
   optional Class class = 1;
-  optional Method get_default_speed = 2;
+  optional Method get_playback_speed = 2;
   optional Method seek_to = 3;
   optional Method on_seek_complete = 4;
   optional Class seek_complete_listener = 5;
-  optional Method set_default_speed = 6;
+  optional Method set_playback_speed = 6;
+  optional Method player_on_prepare = 7;
+  optional Method theseus_player_set_speed = 8;
 }
 
 message PegasusFeed {


### PR DESCRIPTION
修复新版 APP 自定义默认播放速度出现的下列问题: 
- APP 复用 ijkplayer 时, 默认播放速度不生效, 如合集/分P间切换等场景
- 使用新版本播放器时, 无法手动设置 1 倍速(实际已设置为 1 倍速, 但仍显示为自定义的默认播放速度)