### PR TITLE
fix: replace story mode video entirely

### DIFF
--- a/app/src/main/java/me/iacn/biliroaming/hook/ProtoBufHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/ProtoBufHook.kt
@@ -387,5 +387,12 @@ class ProtoBufHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                 }
             }
         }
+
+        if (!sPrefs.getBoolean("replace_story_video", false)) return
+        val disableBooleanValue = "com.bapis.bilibili.app.distribution.BoolValue".from(mClassLoader)?.callStaticMethod("getDefaultInstance") ?: return
+        "com.bapis.bilibili.app.distribution.setting.play.PlayConfig".from(mClassLoader)?.run {
+            replaceAllMethods("getLandscapeAutoStory") { disableBooleanValue }
+            replaceAllMethods("getShouldAutoStory") { disableBooleanValue }
+        }
     }
 }


### PR DESCRIPTION
彻底移除竖版视频 (story mode)的入口
refactor: remove old way to replace story