### PR TITLE
Remove old opt-in for RequiresOptIn

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,7 +81,6 @@ android {
             "-Xno-param-assertions",
             "-Xno-call-assertions",
             "-Xno-receiver-assertions",
-            "-opt-in=kotlin.RequiresOptIn",
             "-language-version=2.0",
         )
     }


### PR DESCRIPTION
As of Kotlin 1.7 the opt-in feature is now stable and does not need an explicit declaration.

https://kotlinlang.org/docs/whatsnew17.html#stable-opt-in-requirements