### PR TITLE
fix: crash when searching sensitive words

### DIFF
--- a/app/src/main/java/me/iacn/biliroaming/hook/BangumiSeasonHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/BangumiSeasonHook.kt
@@ -456,6 +456,10 @@ class BangumiSeasonHook(classLoader: ClassLoader) : BaseHook(classLoader) {
         val navList = v.callMethodAs<List<Any>>("getNavList")
             .map { SearchNav.parseFrom(it.callMethodAs<ByteArray>("toByteArray")) }
             .toMutableList()
+        // fix crash when searching sensitive words
+        if (navList.size == 0) {
+            return
+        }
         val currentArea = runCatchingOrNull {
             XposedInit.country.get(5L, TimeUnit.SECONDS)
         }


### PR DESCRIPTION
在搜索一些敏感词时（比如“药娘”），会因为无法为navList插入元素导致崩溃