### PR TITLE
fix: initHookInfo find biliAccounts class failed on 8.18.0+

### DIFF
--- a/app/src/main/java/me/iacn/biliroaming/BiliBiliPackage.kt
+++ b/app/src/main/java/me/iacn/biliroaming/BiliBiliPackage.kt
@@ -580,10 +580,10 @@ class BiliBiliPackage constructor(private val mClassLoader: ClassLoader, mContex
             }
             biliAccounts = biliAccounts {
                 val biliAccountsClass = dexHelper.findMethodUsingString(
-                    "refresh token error",
+                    "logout with account exception",
                     false,
                     -1,
-                    0,
+                    1,
                     null,
                     -1,
                     null,


### PR DESCRIPTION
应该解决了 8.18.0+ 启动速度缓慢的问题