### PR TITLE
fix: use viewUnite for replaceStoryVideo

### DIFF
--- a/app/src/main/java/me/iacn/biliroaming/hook/StartActivityHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/StartActivityHook.kt
@@ -23,7 +23,6 @@ class StartActivityHook(classLoader: ClassLoader) : BaseHook(classLoader) {
             .appendQueryParameter("aid", original.path?.split("/")?.last() ?: "")
             .appendQueryParameter("bvid", "")
             .build()
-        Log.d(fixedUri)
         return fixedUri
     }
 
@@ -43,7 +42,6 @@ class StartActivityHook(classLoader: ClassLoader) : BaseHook(classLoader) {
             ) {
                 intent.data?.let {
                     try {
-                        Log.e("replaceHook isStory, fix!!!")
                         val cid = intent.data?.getQueryParameter("player_preload").toJSONObject().getLong("cid")
                         intent.data = fixIntentUri(Uri.parse(intent.dataString))
                         // fix extra
@@ -61,20 +59,16 @@ class StartActivityHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                         intent.putExtra("from", 7)
                         intent.putExtra("blrouter.targeturl", pre)
                         intent.putExtra("blrouter.matchrule", "bilibili://united_video/")
-                        Log.d("replaceHook fixedExtras: ${intent.extras}")
                         // fix component
                         intent.component = ComponentName(
                             intent.component?.packageName ?: packageName,
                             "com.bilibili.ship.theseus.detail.UnitedBizDetailsActivity"
                         )
                     } catch (e: Exception) {
-                        Log.e("replaceHook fix failed!!!")
+                        Log.e("replaceStoryVideo fix intent failed!!!")
                         Log.e(e)
-                        Log.e("replaceHook fix failed!!!")
                     }
                 }
-            } else {
-                Log.d("replaceHook default: ${intent.dataString}")
             }
             if (sPrefs.getBoolean("force_browser", false)) {
                 if (intent.component?.className?.endsWith("MWebActivity") == true &&

--- a/app/src/main/java/me/iacn/biliroaming/hook/StartActivityHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/StartActivityHook.kt
@@ -11,8 +11,22 @@ import me.iacn.biliroaming.utils.hookBeforeAllMethods
 import me.iacn.biliroaming.utils.hookBeforeMethod
 import me.iacn.biliroaming.utils.packageName
 import me.iacn.biliroaming.utils.sPrefs
+import me.iacn.biliroaming.utils.toJSONObject
+import kotlin.math.floor
 
 class StartActivityHook(classLoader: ClassLoader) : BaseHook(classLoader) {
+
+    private fun fixIntentUri(original: Uri): Uri {
+        val fixedUri = Uri.parse(original.toString().replace("bilibili://story/", "bilibili://united_video/")).buildUpon()
+            .clearQuery()
+            .appendQueryParameter("from_spmid", original.getQueryParameter("from_spmid"))
+            .appendQueryParameter("aid", original.path?.split("/")?.last() ?: "")
+            .appendQueryParameter("bvid", "")
+            .build()
+        Log.d(fixedUri)
+        return fixedUri
+    }
+
     override fun startHook() {
         "tv.danmaku.bili.ui.intent.IntentHandlerActivity".hookBeforeMethod(mClassLoader, "onCreate", Bundle::class.java) { param ->
             val a = param.thisObject as Activity
@@ -27,11 +41,40 @@ class StartActivityHook(classLoader: ClassLoader) : BaseHook(classLoader) {
                     false
                 ) && uri.startsWith("bilibili://story/")
             ) {
-                intent.component = ComponentName(
-                    intent.component?.packageName ?: packageName,
-                    "com.bilibili.video.videodetail.VideoDetailsActivity"
-                )
-                intent.data = Uri.parse(uri.replace("bilibili://story/", "bilibili://video/"))
+                intent.data?.let {
+                    try {
+                        Log.e("replaceHook isStory, fix!!!")
+                        val cid = intent.data?.getQueryParameter("player_preload").toJSONObject().getLong("cid")
+                        intent.data = fixIntentUri(Uri.parse(intent.dataString))
+                        // fix extra
+                        val pre = Uri.parse(intent.dataString).buildUpon().clearQuery().build().toString()
+                        val aid = pre.split("/").last().toLong()
+                        intent.removeExtra("player_preload")
+                        intent.putExtra("player_preload", floor(Math.random()*1000000000).toInt().toString())
+                        intent.putExtra("blrouter.targeturl", pre)
+                        intent.putExtra("blrouter.pagename", "bilibili://united_video/")
+                        intent.putExtra("jumpFrom", 7)
+                        intent.putExtra("", aid)
+                        intent.putExtra("aid", aid)
+                        intent.putExtra("cid", cid)
+                        intent.putExtra("bvid", "")
+                        intent.putExtra("from", 7)
+                        intent.putExtra("blrouter.targeturl", pre)
+                        intent.putExtra("blrouter.matchrule", "bilibili://united_video/")
+                        Log.d("replaceHook fixedExtras: ${intent.extras}")
+                        // fix component
+                        intent.component = ComponentName(
+                            intent.component?.packageName ?: packageName,
+                            "com.bilibili.ship.theseus.detail.UnitedBizDetailsActivity"
+                        )
+                    } catch (e: Exception) {
+                        Log.e("replaceHook fix failed!!!")
+                        Log.e(e)
+                        Log.e("replaceHook fix failed!!!")
+                    }
+                }
+            } else {
+                Log.d("replaceHook default: ${intent.dataString}")
             }
             if (sPrefs.getBoolean("force_browser", false)) {
                 if (intent.component?.className?.endsWith("MWebActivity") == true &&


### PR DESCRIPTION
替换竖版视频功能使用新版activity，从而解决评论区图片打不开的问题