### PR TITLE
fix: optimize the way to find selectQuality for play ver.

### DIFF
--- a/app/src/main/java/me/iacn/biliroaming/BiliBiliPackage.kt
+++ b/app/src/main/java/me/iacn/biliroaming/BiliBiliPackage.kt
@@ -1945,22 +1945,18 @@ class BiliBiliPackage constructor(private val mClassLoader: ClassLoader, mContex
                     )
                 }.firstNotNullOfOrNull { method ->
                     val methodIdx = dexHelper.encodeMethodIndex(method)
-                    val syntheticMethods = dexHelper.findMethodInvoked(
+                    val isConnectedMethods = dexHelper.findMethodInvoking(
                         methodIdx,
                         dexHelper.encodeClassIndex(Int::class.javaPrimitiveType!!),
-                        4,
+                        1,
                         null,
-                        dexHelper.encodeClassIndex(providerClass),
-                        null,
+                        -1,
+                        longArrayOf(dexHelper.encodeClassIndex(Context::class.java)),
                         null,
                         null,
                         true
                     )
-                    if (syntheticMethods.isEmpty()) {
-                        method
-                    } else {
-                        null
-                    }
+                    if (isConnectedMethods.isEmpty()) method else null
                 } ?: return@qualityStrategyProvider
                 class_ = class_ { name = providerClass.name }
                 selectQuality = method { name = selectQualityMethod.name }

--- a/app/src/main/java/me/iacn/biliroaming/hook/PegasusHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/PegasusHook.kt
@@ -536,27 +536,14 @@ class PegasusHook(classLoader: ClassLoader) : BaseHook(classLoader) {
         }
 
         fun MutableList<Any>.filterUnite() = removeAll {
-
-            val allowTypeList = mutableListOf(
-                2,      // AV(2),
-                3,      // BANGUMI(3),
-                4,      // RESOURCE(4),
-                5,      // GAME(5),
-                6,      // CM(6),
-                7,      // LIVE(7),
-                8,      // BANGUMI_AV(8),
-                9,      // AI_CARD(9),
-                13,     // BANGUMI_UGC(13),
-                14,     // SPECIAL(14),
-                15      // COURSE(15),
-            )
+            val allowTypeList = mutableListOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
             var shouldFiltered = false
             allowTypeList.removeAll { digit ->
                 (removeRelateOnlyAv && digit != 1) || (removeRelatePromote && digit in listOf(
-                    4, // Resource, like mall
-                    5, // GAME
-                    6, // CM
-                    14 // SPECIAL
+                    3, // Resource, like mall
+                    4, // GAME
+                    5, // CM
+                    10 // SPECIAL
                 ))
             }
             // av filter


### PR DESCRIPTION
- 修复play版全屏清晰度

本来以为play版已经修好了，但前几天发现全屏的时候会出现降到半屏设置的清晰度，但这功能我并不怎么用，再者当时已经在修自动点赞了，不想打断思路，就先晾一边了。

上个提交今天重新看了一下代码，发现我理解出了偏差，再加上脑子有点不清醒了，给整错了