### PR TITLE
fix: update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Stop gradle daemon
       run: ./gradlew --stop
     - name: Upload build artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.os }}-artifact
         path: |

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -47,7 +47,7 @@ jobs:
           ./gradlew -PappVerName=${{ env.VERSION }} assembleRelease assembleDebug
       - name: Upload built apk
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: snapshot
           path: |


### PR DESCRIPTION
v3 版本的 `actions/upload-artifact` 和 `actions/download-artifact` 已被弃用： https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

替换为v4版本。

在fork测试了两个actions
- [Android CI](https://github.com/SlowpokeFisher/BiliRoaming/actions/runs/13349579134)
- [PR Build](https://github.com/SlowpokeFisher/BiliRoaming/actions/runs/13349516573)