### PR TITLE
Fix: 评论自由复制

### DIFF
--- a/app/src/main/java/me/iacn/biliroaming/XposedInit.kt
+++ b/app/src/main/java/me/iacn/biliroaming/XposedInit.kt
@@ -99,6 +99,7 @@ class XposedInit : IXposedHookLoadPackage, IXposedHookZygoteInit {
                     startHook { CoverHook(lpparam.classLoader) }
                     startHook { SubtitleHook(lpparam.classLoader) }
                     startHook { CopyHook(lpparam.classLoader) }
+                    startHook { CopyCommentHook(lpparam.classLoader) }
                     startHook { LiveRoomHook(lpparam.classLoader) }
                     startHook { QualityHook(lpparam.classLoader) }
                     startHook { DynamicHook(lpparam.classLoader) }

--- a/app/src/main/java/me/iacn/biliroaming/hook/CopyCommentHook.kt
+++ b/app/src/main/java/me/iacn/biliroaming/hook/CopyCommentHook.kt
@@ -1,0 +1,49 @@
+package me.iacn.biliroaming.hook
+
+import android.app.AlertDialog
+import android.content.ClipboardManager
+import android.content.Context
+import android.view.View
+import android.widget.TextView
+import de.robv.android.xposed.XC_MethodHook
+import de.robv.android.xposed.XposedHelpers
+import me.iacn.biliroaming.utils.currentContext
+import me.iacn.biliroaming.utils.getResId
+import me.iacn.biliroaming.utils.sPrefs
+
+
+class CopyCommentHook(classLoader: ClassLoader) : BaseHook(classLoader) {
+    override fun startHook() {
+        if (!sPrefs.getBoolean("copy_comment", false)) return
+        XposedHelpers.findAndHookMethod(
+            "com.bilibili.app.comment3.ui.widget.menu.CommentMoreMenuItemHolder",
+            mClassLoader,
+            "y3",
+            "kotlin.jvm.functions.Function1",
+            "com.bilibili.app.comment3.data.model.CommentItem\$MenuItem",
+            "android.view.View",  // ConstraintLayout
+            object : XC_MethodHook() {
+                override fun afterHookedMethod(param: MethodHookParam) {
+                    super.afterHookedMethod(param)
+                    val menu = param.args[1]
+                    val view = param.args[2] as View
+                    if (!menu.toString().contains("COPY")) return
+
+                    val clipboard =
+                        currentContext.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                    // 实在是找不到了。那你就说有没有获取到吧
+                    val txt = clipboard.primaryClip!!.getItemAt(0).text
+                    AlertDialog.Builder(view.context, getResId("AppTheme.Dialog.Alert", "style"))
+                        .run {
+                            setTitle("自由复制内容")
+                            setMessage(txt)
+                            setPositiveButton("完成") { _, _ -> }
+                            setNegativeButton("复制全部") { _, _ -> }
+                            show()
+                        }.apply {
+                            findViewById<TextView>(android.R.id.message).setTextIsSelectable(true)
+                        }
+                }
+            })
+    }
+}

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -115,6 +115,8 @@
     <string name="comment_copy_title">去除長按複製</string>
     <string name="comment_copy_enhance_title">長按自由複製</string>
     <string name="comment_copy_enhance_summary">長按私信/評論/動態/影片簡介時彈出自由選擇對話框，需要開啟「去除長按複製」</string>
+    <string name="copy_comment_title">评论自由复制</string>
+    <string name="copy_comment_summary">评论复制按钮可以自由复制</string>
     <string name="revert_live_room_feed_title">強制舊版直播間樣式</string>
     <string name="revert_live_room_feed_summary">強制直播間使用舊版樣式</string>
     <string name="block_video_ad_title">封鎖影片下方推薦</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,6 +117,8 @@
     <string name="comment_copy_title">去除长按复制</string>
     <string name="comment_copy_enhance_title">长按自由复制</string>
     <string name="comment_copy_enhance_summary">长按私信/评论/动态/视频简介时弹出自由选择对话框，需要开启“去除长按复制”</string>
+    <string name="copy_comment_title">评论自由复制</string>
+    <string name="copy_comment_summary">评论复制按钮可以自由复制</string>
     <string name="revert_live_room_feed_title">强制旧版直播间样式</string>
     <string name="revert_live_room_feed_summary">强制直播间使用旧版样式</string>
     <string name="block_video_ad_title">屏蔽视频下方推荐</string>

--- a/app/src/main/res/xml/prefs_setting.xml
+++ b/app/src/main/res/xml/prefs_setting.xml
@@ -129,6 +129,11 @@
             android:title="@string/comment_copy_enhance_title" />
 
         <SwitchPreference
+            android:key="copy_comment"
+            android:summary="@string/copy_comment_summary"
+            android:title="@string/copy_comment_title" />
+
+        <SwitchPreference
             android:key="mini_program"
             android:summary="@string/mini_program_summary"
             android:title="@string/mini_program_title" />
@@ -243,7 +248,7 @@
             android:entryValues="@array/live_quality_values"
             android:key="live_quality"
             android:summary="@string/live_quality_summary"
-            android:title="@string/live_quality_title"/>
+            android:title="@string/live_quality_title" />
 
         <SwitchPreference
             android:key="block_comment_guide"
@@ -283,8 +288,8 @@
         <SwitchPreference
             android:defaultValue="false"
             android:key="fake_non_multiwindow"
-            android:title="@string/fake_non_multiwindow_title"
-            android:summary="@string/fake_non_multiwindow_summary"/>
+            android:summary="@string/fake_non_multiwindow_summary"
+            android:title="@string/fake_non_multiwindow_title" />
 
         <Preference
             android:defaultValue="300"
@@ -541,8 +546,8 @@
 
         <Preference
             android:key="copy_access_key"
-            android:title="@string/copy_access_key_title"
-            android:summary="@string/copy_access_key_summary" />
+            android:summary="@string/copy_access_key_summary"
+            android:title="@string/copy_access_key_title" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/setting_category">


### PR DESCRIPTION
# 评论自由复制，适配 `8.71.0`。
## 描述
在新版，评论长按后有单独的菜单，包含了复制功能，但没有提供自由复制。**此更改仅对这个复制起效**，所以旧版本依旧可用之前的 Hook。

## 还没做，但不会做
- [ ] 繁体翻译。
- [ ] 使用动态 Hook，但是这个类有两个一样的函数（参数、返回值都一样）。目前使用 hardcode.

## 其他说明
- `pref_settings.xml` 一次把所有的格式化了。